### PR TITLE
Replace latest_trace_id by tx_start_traceparent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ OBJS = \
 	src/pg_tracing_span.o \
 	src/version_compat.o
 
-REGRESSCHECKS = setup utility select insert trigger cursor
+REGRESSCHECKS = setup utility select insert trigger cursor transaction
 ifeq ($(PG_VERSION),15)
 REGRESSCHECKS += trigger_15
 else

--- a/expected/cursor.out
+++ b/expected/cursor.out
@@ -1,10 +1,10 @@
-BEGIN;
-/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000001-0000000000000001-01'*/ DECLARE c CURSOR FOR SELECT * from pg_tracing_test;
-/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000001-0000000000000002-01'*/ FETCH FORWARD 20 from c \gset
+/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000001-0000000000000001-01'*/ BEGIN;
+DECLARE c CURSOR FOR SELECT * from pg_tracing_test;
+FETCH FORWARD 20 from c \gset
 more than one row returned for \gset
-/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000001-0000000000000003-01'*/ FETCH BACKWARD 10 from c \gset
+FETCH BACKWARD 10 from c \gset
 more than one row returned for \gset
-/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000001-0000000000000004-01'*/ CLOSE c;
+CLOSE c;
 COMMIT;
 -- First declare
 -- +----------------------------------------+
@@ -20,7 +20,8 @@ SELECT span_id AS span_a_id,
         get_epoch(span_start) as span_a_start,
         get_epoch(span_end) as span_a_end
 		from pg_tracing_peek_spans
-        where trace_id='00000000000000000000000000000001' AND parent_id='0000000000000001' \gset
+        where trace_id='00000000000000000000000000000001' AND parent_id='0000000000000001'
+          AND span_operation='DECLARE c CURSOR FOR SELECT * from pg_tracing_test;' \gset
 SELECT span_id AS span_b_id,
         get_epoch(span_start) as span_b_start,
         get_epoch(span_end) as span_b_end
@@ -63,7 +64,8 @@ SELECT span_id AS span_a_id,
         get_epoch(span_start) as span_a_start,
         get_epoch(span_end) as span_a_end
 		from pg_tracing_peek_spans
-        where trace_id='00000000000000000000000000000001' AND parent_id='0000000000000002' \gset
+        where trace_id='00000000000000000000000000000001' AND parent_id='0000000000000001'
+          AND span_operation='FETCH FORWARD 20 from c' \gset
 SELECT span_id AS span_b_id,
         get_epoch(span_start) as span_b_start,
         get_epoch(span_end) as span_b_end
@@ -98,7 +100,8 @@ SELECT span_id AS span_a_id,
         get_epoch(span_start) as span_a_start,
         get_epoch(span_end) as span_a_end
 		from pg_tracing_peek_spans
-        where trace_id='00000000000000000000000000000001' AND parent_id='0000000000000003' \gset
+        where trace_id='00000000000000000000000000000001' AND parent_id='0000000000000001'
+          AND span_operation='FETCH BACKWARD 10 from c' \gset
 SELECT span_id AS span_b_id,
         get_epoch(span_start) as span_b_start,
         get_epoch(span_end) as span_b_end
@@ -131,6 +134,8 @@ SELECT :span_c_start >= :span_b_start as nested_declare_starts_after_parent,
 SELECT span_type, span_operation, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000001';
    span_type    |                   span_operation                    | lvl 
 ----------------+-----------------------------------------------------+-----
+ Utility query  | BEGIN;                                              |   1
+ ProcessUtility | ProcessUtility                                      |   2
  Utility query  | DECLARE c CURSOR FOR SELECT * from pg_tracing_test; |   1
  ProcessUtility | ProcessUtility                                      |   2
  Select query   | DECLARE c CURSOR FOR SELECT * from pg_tracing_test; |   3
@@ -146,7 +151,9 @@ SELECT span_type, span_operation, lvl from peek_ordered_spans where trace_id='00
  Utility query  | CLOSE c;                                            |   1
  ProcessUtility | ProcessUtility                                      |   2
  Select query   | DECLARE c CURSOR FOR SELECT * from pg_tracing_test; |   3
-(15 rows)
+ Utility query  | COMMIT;                                             |   1
+ ProcessUtility | ProcessUtility                                      |   2
+(19 rows)
 
 -- Clean created spans
 CALL clean_spans();

--- a/expected/select.out
+++ b/expected/select.out
@@ -211,13 +211,17 @@ SELECT 1\; SELECT 1, 2;
 (1 row)
 
 SELECT span_type, span_operation, parameters, lvl from peek_ordered_spans;
-  span_type   | span_operation | parameters | lvl 
---------------+----------------+------------+-----
- Select query | SELECT $1;     | $1 = 1     |   1
- Planner      | Planner        |            |   2
- Executor     | ExecutorRun    |            |   2
- Result       | Result         |            |   3
-(4 rows)
+  span_type   | span_operation |   parameters   | lvl 
+--------------+----------------+----------------+-----
+ Select query | SELECT $1;     | $1 = 1         |   1
+ Planner      | Planner        |                |   2
+ Executor     | ExecutorRun    |                |   2
+ Result       | Result         |                |   3
+ Select query | SELECT $1, $2; | $1 = 1, $2 = 2 |   1
+ Planner      | Planner        |                |   2
+ Executor     | ExecutorRun    |                |   2
+ Result       | Result         |                |   3
+(8 rows)
 
 CALL clean_spans();
 -- Check standalone trace

--- a/expected/transaction.out
+++ b/expected/transaction.out
@@ -1,0 +1,51 @@
+-- Only trace queries with sample flag
+SET pg_tracing.sample_rate = 0.0;
+SET pg_tracing.caller_sample_rate = 1.0;
+-- Set tracecontext at the start of the transaction
+/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000001-0000000000000001-01'*/ BEGIN; SELECT 1; COMMIT;
+ ?column? 
+----------
+        1
+(1 row)
+
+SELECT span_type, span_operation, lvl FROM peek_ordered_spans where trace_id='00000000000000000000000000000001';
+   span_type    | span_operation | lvl 
+----------------+----------------+-----
+ Utility query  | BEGIN;         |   1
+ ProcessUtility | ProcessUtility |   2
+ Select query   | SELECT $1;     |   1
+ Planner        | Planner        |   2
+ Executor       | ExecutorRun    |   2
+ Result         | Result         |   3
+ Utility query  | COMMIT;        |   1
+ ProcessUtility | ProcessUtility |   2
+(8 rows)
+
+-- Test with override of the trace context in the middle of a transaction
+/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000002-0000000000000002-01'*/ BEGIN;
+/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000003-0000000000000003-01'*/ SELECT 1; COMMIT;
+ ?column? 
+----------
+        1
+(1 row)
+
+SELECT span_type, span_operation, lvl FROM peek_ordered_spans where trace_id='00000000000000000000000000000002';
+   span_type    | span_operation | lvl 
+----------------+----------------+-----
+ Utility query  | BEGIN;         |   1
+ ProcessUtility | ProcessUtility |   2
+ Utility query  | COMMIT;        |   1
+ ProcessUtility | ProcessUtility |   2
+(4 rows)
+
+SELECT span_type, span_operation, lvl FROM peek_ordered_spans where trace_id='00000000000000000000000000000003';
+  span_type   | span_operation | lvl 
+--------------+----------------+-----
+ Select query | SELECT $1;     |   1
+ Planner      | Planner        |   2
+ Executor     | ExecutorRun    |   2
+ Result       | Result         |   3
+(4 rows)
+
+CALL clean_spans();
+CALL reset_settings();

--- a/sql/cursor.sql
+++ b/sql/cursor.sql
@@ -1,8 +1,8 @@
-BEGIN;
-/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000001-0000000000000001-01'*/ DECLARE c CURSOR FOR SELECT * from pg_tracing_test;
-/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000001-0000000000000002-01'*/ FETCH FORWARD 20 from c \gset
-/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000001-0000000000000003-01'*/ FETCH BACKWARD 10 from c \gset
-/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000001-0000000000000004-01'*/ CLOSE c;
+/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000001-0000000000000001-01'*/ BEGIN;
+DECLARE c CURSOR FOR SELECT * from pg_tracing_test;
+FETCH FORWARD 20 from c \gset
+FETCH BACKWARD 10 from c \gset
+CLOSE c;
 COMMIT;
 
 -- First declare
@@ -20,7 +20,8 @@ SELECT span_id AS span_a_id,
         get_epoch(span_start) as span_a_start,
         get_epoch(span_end) as span_a_end
 		from pg_tracing_peek_spans
-        where trace_id='00000000000000000000000000000001' AND parent_id='0000000000000001' \gset
+        where trace_id='00000000000000000000000000000001' AND parent_id='0000000000000001'
+          AND span_operation='DECLARE c CURSOR FOR SELECT * from pg_tracing_test;' \gset
 SELECT span_id AS span_b_id,
         get_epoch(span_start) as span_b_start,
         get_epoch(span_end) as span_b_end
@@ -57,7 +58,8 @@ SELECT span_id AS span_a_id,
         get_epoch(span_start) as span_a_start,
         get_epoch(span_end) as span_a_end
 		from pg_tracing_peek_spans
-        where trace_id='00000000000000000000000000000001' AND parent_id='0000000000000002' \gset
+        where trace_id='00000000000000000000000000000001' AND parent_id='0000000000000001'
+          AND span_operation='FETCH FORWARD 20 from c' \gset
 SELECT span_id AS span_b_id,
         get_epoch(span_start) as span_b_start,
         get_epoch(span_end) as span_b_end
@@ -85,7 +87,8 @@ SELECT span_id AS span_a_id,
         get_epoch(span_start) as span_a_start,
         get_epoch(span_end) as span_a_end
 		from pg_tracing_peek_spans
-        where trace_id='00000000000000000000000000000001' AND parent_id='0000000000000003' \gset
+        where trace_id='00000000000000000000000000000001' AND parent_id='0000000000000001'
+          AND span_operation='FETCH BACKWARD 10 from c' \gset
 SELECT span_id AS span_b_id,
         get_epoch(span_start) as span_b_start,
         get_epoch(span_end) as span_b_end

--- a/sql/transaction.sql
+++ b/sql/transaction.sql
@@ -1,0 +1,18 @@
+-- Only trace queries with sample flag
+SET pg_tracing.sample_rate = 0.0;
+SET pg_tracing.caller_sample_rate = 1.0;
+
+-- Set tracecontext at the start of the transaction
+/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000001-0000000000000001-01'*/ BEGIN; SELECT 1; COMMIT;
+
+SELECT span_type, span_operation, lvl FROM peek_ordered_spans where trace_id='00000000000000000000000000000001';
+
+-- Test with override of the trace context in the middle of a transaction
+/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000002-0000000000000002-01'*/ BEGIN;
+/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000003-0000000000000003-01'*/ SELECT 1; COMMIT;
+
+SELECT span_type, span_operation, lvl FROM peek_ordered_spans where trace_id='00000000000000000000000000000002';
+SELECT span_type, span_operation, lvl FROM peek_ordered_spans where trace_id='00000000000000000000000000000003';
+
+CALL clean_spans();
+CALL reset_settings();


### PR DESCRIPTION
 If the start of a transaction has a trace_context, we want to reuse it for the whole transaction. Replace latest_trace_id by tx_start_traceparent which will only be set at the start of a new transaction and update it with both randomly generated trace_id and extracted_trace_id from SQLComments.

If a statement has its own tracecontext, we give it priority.

This fixes the issue #13 where latest_trace_id was not updated when trace_id was provided by SQLComment, leading to creating spans with a 0 trace_id.