### PR TITLE
Reworked top spans and nested level

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ OBJS = \
 	src/pg_tracing_explain.o \
 	src/pg_tracing_span.o \
 	src/pg_tracing_sql_functions.o \
-	src/pg_tracing_top_spans.o \
+	src/pg_tracing_active_spans.o \
 	src/version_compat.o
 
 REGRESSCHECKS = setup utility select insert trigger cursor transaction

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ OBJS = \
 	src/pg_tracing_explain.o \
 	src/pg_tracing_span.o \
 	src/pg_tracing_sql_functions.o \
+	src/pg_tracing_top_spans.o \
 	src/version_compat.o
 
 REGRESSCHECKS = setup utility select insert trigger cursor transaction

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ OBJS = \
 	src/pg_tracing_planstate.o \
 	src/pg_tracing_explain.o \
 	src/pg_tracing_span.o \
+	src/pg_tracing_sql_functions.o \
 	src/version_compat.o
 
 REGRESSCHECKS = setup utility select insert trigger cursor transaction

--- a/expected/extended.out
+++ b/expected/extended.out
@@ -134,6 +134,7 @@ SELECT 1 \gdesc
 SELECT span_type, span_operation, parameters, lvl FROM peek_ordered_spans;
   span_type   |                           span_operation                           |             parameters              | lvl 
 --------------+--------------------------------------------------------------------+-------------------------------------+-----
+ Select query | SELECT $1                                                          | $1 = 1                              |   1
  Commit       | Commit                                                             |                                     |   1
  Select query | SELECT name AS "Column", pg_catalog.format_type(tp, tpm) AS "Type"+| $1 = '?column?', $2 = '23', $3 = -1 |   1
               | FROM (VALUES ($1, $2::pg_catalog.oid,$3)) s(name, tp, tpm)         |                                     | 
@@ -141,6 +142,6 @@ SELECT span_type, span_operation, parameters, lvl FROM peek_ordered_spans;
  Executor     | ExecutorRun                                                        |                                     |   2
  Result       | Result                                                             |                                     |   3
  Commit       | Commit                                                             |                                     |   1
-(6 rows)
+(7 rows)
 
 CALL clean_spans();

--- a/expected/nested.out
+++ b/expected/nested.out
@@ -164,15 +164,16 @@ LANGUAGE sql IMMUTABLE;
 (1 row)
 
 select span_operation, lvl FROM peek_ordered_spans where trace_id='00000000000000000000000000000056';
-           span_operation            | lvl 
--------------------------------------+-----
- select test_immutable_function($1); |   1
- Planner                             |   2
- Planner                             |   3
- ExecutorRun                         |   2
- Result                              |   3
- Commit                              |   1
-(6 rows)
+             span_operation              | lvl 
+-----------------------------------------+-----
+ select test_immutable_function($1);     |   1
+ Planner                                 |   2
+ SELECT oid from pg_class where oid = a; |   3
+ Planner                                 |   4
+ ExecutorRun                             |   2
+ Result                                  |   3
+ Commit                                  |   1
+(7 rows)
 
 -- Create function with generate series
 CREATE OR REPLACE FUNCTION test_generate_series(IN anyarray, OUT x anyelement)

--- a/src/pg_tracing.c
+++ b/src/pg_tracing.c
@@ -260,6 +260,8 @@ static pgTracingStats get_empty_pg_tracing_stats(void);
 static bool check_filter_query_ids(char **newval, void **extra, GucSource source);
 static void assign_filter_query_ids(const char *newval, void *extra);
 
+static void initialize_trace_level(void);
+
 static void cleanup_tracing(void);
 static void pg_tracing_xact_callback(XactEvent event, void *arg);
 
@@ -688,6 +690,188 @@ end_latest_top_span(const TimestampTz *end_time, bool pop_span)
 		/* Restore previous top span */
 		pop_top_span();
 	}
+}
+
+/*
+ * Start a new top span if we've entered a new nested level or if the previous
+ * span at the same level ended.
+ */
+static void
+begin_top_span(pgTracingTraceContext * trace_context, Span * top_span,
+			   CmdType commandType, const Query *query, const JumbleState *jstate,
+			   const PlannedStmt *pstmt, const char *query_text, TimestampTz start_time)
+{
+	int			query_len;
+	const char *normalised_query;
+	uint64		parent_id;
+	int8		parent_planstate_index = -1;
+
+	/* in case of a cached plan, query might be unavailable */
+	if (query != NULL)
+		per_level_buffers[exec_nested_level].query_id = query->queryId;
+	else if (trace_context->query_id > 0)
+		per_level_buffers[exec_nested_level].query_id = trace_context->query_id;
+
+	if (exec_nested_level <= 0)
+		/* Root top span, use the parent id from the trace context */
+		parent_id = trace_context->traceparent.parent_id;
+	else
+	{
+		TracedPlanstate *parent_traced_planstate = NULL;
+		Span	   *latest_top_span = NULL;
+
+		/*
+		 * We're in a nested level, check if we have a parent planstate and
+		 * use it as a parent span
+		 */
+		parent_planstate_index = get_parent_traced_planstate_index(exec_nested_level);
+		if (parent_planstate_index > -1)
+			parent_traced_planstate = get_traced_planstate_from_index(parent_planstate_index);
+		latest_top_span = get_latest_top_span(exec_nested_level - 1);
+
+		/*
+		 * Both planstate and previous top span can be the parent for the new
+		 * top span, we use the most recent as a parent
+		 */
+		if (parent_traced_planstate != NULL && parent_traced_planstate->node_start >= latest_top_span->start)
+			parent_id = parent_traced_planstate->span_id;
+		else
+			parent_id = latest_top_span->span_id;
+	}
+
+	begin_span(trace_context->traceparent.trace_id, top_span,
+			   command_type_to_span_type(commandType),
+			   NULL, parent_id,
+			   per_level_buffers[exec_nested_level].query_id, &start_time);
+	/* Keep track of the parent planstate index */
+	top_span->parent_planstate_index = parent_planstate_index;
+
+	if (IsParallelWorker())
+	{
+		/*
+		 * In a parallel worker, we use the worker name as the span's
+		 * operation
+		 */
+		top_span->operation_name_offset = add_worker_name_to_trace_buffer(current_trace_text, ParallelWorkerNumber);
+		return;
+	}
+
+	if (jstate && jstate->clocations_count > 0 && query != NULL)
+	{
+		/* jstate is available, normalise query and extract parameters' values */
+		char	   *param_str;
+		int			param_len;
+
+		query_len = query->stmt_len;
+		normalised_query = normalise_query_parameters(jstate, query_text,
+													  query->stmt_location, &query_len,
+													  &param_str, &param_len);
+		Assert(param_len > 0);
+		if (pg_tracing_export_parameters)
+			top_span->parameter_offset = add_str_to_trace_buffer(param_str, param_len);
+	}
+	else
+	{
+		/*
+		 * No jstate available, normalise query but we won't be able to
+		 * extract parameters
+		 */
+		int			stmt_location;
+
+		if (query != NULL && query->stmt_len > 0)
+		{
+			query_len = query->stmt_len;
+			stmt_location = query->stmt_location;
+		}
+		else if (pstmt != NULL && pstmt->stmt_location != -1 && pstmt->stmt_len > 0)
+		{
+			query_len = pstmt->stmt_len;
+			stmt_location = pstmt->stmt_location;
+		}
+		else
+		{
+			query_len = strlen(query_text);
+			stmt_location = 0;
+		}
+		normalised_query = normalise_query(query_text, stmt_location, &query_len);
+	}
+	if (query_len > 0)
+		top_span->operation_name_offset = add_str_to_trace_buffer(normalised_query,
+																  query_len);
+}
+
+/*
+ * Get the ongoing top span if it exists or create it
+ */
+static Span *
+get_or_allocate_top_span(pgTracingTraceContext * trace_context, bool in_parse_or_plan)
+{
+	Span	   *span;
+
+	if (in_parse_or_plan && exec_nested_level == 0)
+
+		/*
+		 * The root post parse and plan, we want to use trace_context's
+		 * root_span as the top span in per_level_buffers might still be
+		 * ongoing.
+		 */
+		return &trace_context->root_span;
+
+	if (per_level_buffers[exec_nested_level].top_spans->end == 0)
+		/* No spans were created in this level, allocate a new one */
+		span = allocate_new_top_span();
+	else
+		span = get_latest_top_span(exec_nested_level);
+
+	if (exec_nested_level == 0)
+
+		/*
+		 * At root level and outside of parse/plan hook, we need to copy the
+		 * root span content
+		 */
+		*span = trace_context->root_span;
+
+	return span;
+}
+
+/*
+ * Initialise buffers if we are in a new nested level and start associated top span.
+ * If the top span already exists for the current nested level, this has no effect.
+ *
+ * This needs to be called every time a top span could be started: post parse,
+ * planner, executor start and process utility
+ */
+static uint64
+initialize_top_span(pgTracingTraceContext * trace_context, CmdType commandType,
+					Query *query, JumbleState *jstate, const PlannedStmt *pstmt,
+					const char *query_text, TimestampTz start_time,
+					bool in_parse_or_plan)
+{
+	Span	   *top_span;
+
+	/* Make sure we have allocated the level */
+	initialize_trace_level();
+
+	top_span = get_or_allocate_top_span(trace_context, in_parse_or_plan);
+
+	/* If the top_span is still ongoing, use it as it is */
+	if (top_span->span_id > 0 && top_span->ended == false)
+		return top_span->span_id;
+
+	/* current_trace_spans buffer should have been allocated */
+	Assert(current_trace_spans != NULL);
+
+	if (top_span->span_id > 0)
+	{
+		/* The previous top span was closed, create a new one */
+		Assert(top_span->ended);
+		top_span = allocate_new_top_span();
+	}
+
+	/* This is a new top span, start it */
+	begin_top_span(trace_context, top_span, commandType, query, jstate, pstmt,
+				   query_text, start_time);
+	return top_span->span_id;
 }
 
 /*
@@ -1306,188 +1490,6 @@ initialize_trace_level(void)
 		MemoryContextSwitchTo(oldcxt);
 	}
 	max_nested_level = exec_nested_level;
-}
-
-/*
- * Start a new top span if we've entered a new nested level or if the previous
- * span at the same level ended.
- */
-static void
-begin_top_span(pgTracingTraceContext * trace_context, Span * top_span,
-			   CmdType commandType, const Query *query, const JumbleState *jstate,
-			   const PlannedStmt *pstmt, const char *query_text, TimestampTz start_time)
-{
-	int			query_len;
-	const char *normalised_query;
-	uint64		parent_id;
-	int8		parent_planstate_index = -1;
-
-	/* in case of a cached plan, query might be unavailable */
-	if (query != NULL)
-		per_level_buffers[exec_nested_level].query_id = query->queryId;
-	else if (trace_context->query_id > 0)
-		per_level_buffers[exec_nested_level].query_id = trace_context->query_id;
-
-	if (exec_nested_level <= 0)
-		/* Root top span, use the parent id from the trace context */
-		parent_id = trace_context->traceparent.parent_id;
-	else
-	{
-		TracedPlanstate *parent_traced_planstate = NULL;
-		Span	   *latest_top_span = NULL;
-
-		/*
-		 * We're in a nested level, check if we have a parent planstate and
-		 * use it as a parent span
-		 */
-		parent_planstate_index = get_parent_traced_planstate_index(exec_nested_level);
-		if (parent_planstate_index > -1)
-			parent_traced_planstate = get_traced_planstate_from_index(parent_planstate_index);
-		latest_top_span = get_latest_top_span(exec_nested_level - 1);
-
-		/*
-		 * Both planstate and previous top span can be the parent for the new
-		 * top span, we use the most recent as a parent
-		 */
-		if (parent_traced_planstate != NULL && parent_traced_planstate->node_start >= latest_top_span->start)
-			parent_id = parent_traced_planstate->span_id;
-		else
-			parent_id = latest_top_span->span_id;
-	}
-
-	begin_span(trace_context->traceparent.trace_id, top_span,
-			   command_type_to_span_type(commandType),
-			   NULL, parent_id,
-			   per_level_buffers[exec_nested_level].query_id, &start_time);
-	/* Keep track of the parent planstate index */
-	top_span->parent_planstate_index = parent_planstate_index;
-
-	if (IsParallelWorker())
-	{
-		/*
-		 * In a parallel worker, we use the worker name as the span's
-		 * operation
-		 */
-		top_span->operation_name_offset = add_worker_name_to_trace_buffer(current_trace_text, ParallelWorkerNumber);
-		return;
-	}
-
-	if (jstate && jstate->clocations_count > 0 && query != NULL)
-	{
-		/* jstate is available, normalise query and extract parameters' values */
-		char	   *param_str;
-		int			param_len;
-
-		query_len = query->stmt_len;
-		normalised_query = normalise_query_parameters(jstate, query_text,
-													  query->stmt_location, &query_len,
-													  &param_str, &param_len);
-		Assert(param_len > 0);
-		if (pg_tracing_export_parameters)
-			top_span->parameter_offset = add_str_to_trace_buffer(param_str, param_len);
-	}
-	else
-	{
-		/*
-		 * No jstate available, normalise query but we won't be able to
-		 * extract parameters
-		 */
-		int			stmt_location;
-
-		if (query != NULL && query->stmt_len > 0)
-		{
-			query_len = query->stmt_len;
-			stmt_location = query->stmt_location;
-		}
-		else if (pstmt != NULL && pstmt->stmt_location != -1 && pstmt->stmt_len > 0)
-		{
-			query_len = pstmt->stmt_len;
-			stmt_location = pstmt->stmt_location;
-		}
-		else
-		{
-			query_len = strlen(query_text);
-			stmt_location = 0;
-		}
-		normalised_query = normalise_query(query_text, stmt_location, &query_len);
-	}
-	if (query_len > 0)
-		top_span->operation_name_offset = add_str_to_trace_buffer(normalised_query,
-																  query_len);
-}
-
-/*
- * Get the ongoing top span if it exists or create it
- */
-static Span *
-get_or_allocate_top_span(pgTracingTraceContext * trace_context, bool in_parse_or_plan)
-{
-	Span	   *span;
-
-	if (in_parse_or_plan && exec_nested_level == 0)
-
-		/*
-		 * The root post parse and plan, we want to use trace_context's
-		 * root_span as the top span in per_level_buffers might still be
-		 * ongoing.
-		 */
-		return &trace_context->root_span;
-
-	if (per_level_buffers[exec_nested_level].top_spans->end == 0)
-		/* No spans were created in this level, allocate a new one */
-		span = allocate_new_top_span();
-	else
-		span = get_latest_top_span(exec_nested_level);
-
-	if (exec_nested_level == 0)
-
-		/*
-		 * At root level and outside of parse/plan hook, we need to copy the
-		 * root span content
-		 */
-		*span = trace_context->root_span;
-
-	return span;
-}
-
-/*
- * Initialise buffers if we are in a new nested level and start associated top span.
- * If the top span already exists for the current nested level, this has no effect.
- *
- * This needs to be called every time a top span could be started: post parse,
- * planner, executor start and process utility
- */
-static uint64
-initialize_top_span(pgTracingTraceContext * trace_context, CmdType commandType,
-					Query *query, JumbleState *jstate, const PlannedStmt *pstmt,
-					const char *query_text, TimestampTz start_time,
-					bool in_parse_or_plan)
-{
-	Span	   *top_span;
-
-	/* Make sure we have allocated the level */
-	initialize_trace_level();
-
-	top_span = get_or_allocate_top_span(trace_context, in_parse_or_plan);
-
-	/* If the top_span is still ongoing, use it as it is */
-	if (top_span->span_id > 0 && top_span->ended == false)
-		return top_span->span_id;
-
-	/* current_trace_spans buffer should have been allocated */
-	Assert(current_trace_spans != NULL);
-
-	if (top_span->span_id > 0)
-	{
-		/* The previous top span was closed, create a new one */
-		Assert(top_span->ended);
-		top_span = allocate_new_top_span();
-	}
-
-	/* This is a new top span, start it */
-	begin_top_span(trace_context, top_span, commandType, query, jstate, pstmt,
-				   query_text, start_time);
-	return top_span->span_id;
 }
 
 /*

--- a/src/pg_tracing.c
+++ b/src/pg_tracing.c
@@ -587,6 +587,14 @@ end_nested_level(void)
 		return span_end_time;
 
 	top_span = peek_top_span();
+	if (top_span == NULL && parsed_trace_context.root_span.span_id > 0 && exec_nested_level == 0)
+
+		/*
+		 * If we only had a parse command (like calling \gdesc), the span will
+		 * only be stored in the parsed_trace_context, use it
+		 */
+		top_span = &parsed_trace_context.root_span;
+
 	while (top_span != NULL && top_span->nested_level == exec_nested_level)
 	{
 		TimestampTz top_span_end = span_end_time;

--- a/src/pg_tracing.c
+++ b/src/pg_tracing.c
@@ -1401,6 +1401,7 @@ pg_tracing_ExecutorStart(QueryDesc *queryDesc, int eflags)
 	{
 		/* We're at the root level, copy trace context from parsing/planning */
 		*trace_context = parsed_trace_context;
+		reset_trace_context(&parsed_trace_context);
 	}
 
 	/* Evaluate if query is sampled or not */
@@ -1740,6 +1741,7 @@ pg_tracing_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 	{
 		/* We're at root level, copy the root trace_context */
 		*trace_context = parsed_trace_context;
+		reset_trace_context(&parsed_trace_context);
 	}
 
 	parsetree = pstmt->utilityStmt;

--- a/src/pg_tracing.c
+++ b/src/pg_tracing.c
@@ -1011,7 +1011,6 @@ cleanup_tracing(void)
 		!executor_trace_context.traceparent.sampled)
 		/* No need for cleaning */
 		return;
-	cleanup_top_spans();
 	MemoryContextReset(pg_tracing_mem_ctx);
 	reset_trace_context(&parsed_trace_context);
 	reset_trace_context(&executor_trace_context);
@@ -1020,6 +1019,7 @@ cleanup_tracing(void)
 	current_trace_spans = NULL;
 	per_level_buffers = NULL;
 	cleanup_planstarts();
+	cleanup_top_spans();
 }
 
 /*

--- a/src/pg_tracing.c
+++ b/src/pg_tracing.c
@@ -78,16 +78,6 @@ typedef enum
 }			pgTracingBufferMode;
 
 /*
- * Structure to store flexible array of spans
- */
-typedef struct pgTracingSpans
-{
-	int			end;			/* Index of last element */
-	int			max;			/* Maximum number of element */
-	Span		spans[FLEXIBLE_ARRAY_MEMBER];
-}			pgTracingSpans;
-
-/*
  * Structure to store per exec level informations
  */
 typedef struct pgTracingPerLevelBuffer

--- a/src/pg_tracing.c
+++ b/src/pg_tracing.c
@@ -551,20 +551,6 @@ add_str_to_trace_buffer(const char *str, int str_len)
 
 
 /*
- * Add the worker name to the provided stringinfo
- */
-static int
-add_worker_name_to_trace_buffer(StringInfo str_info, int parallel_worker_number)
-{
-	int			position = str_info->cursor;
-
-	appendStringInfo(str_info, "Worker %d", parallel_worker_number);
-	appendStringInfoChar(str_info, '\0');
-	str_info->cursor = str_info->len;
-	return position;
-}
-
-/*
  * Store a span in the current_trace_spans buffer
  */
 void
@@ -614,114 +600,6 @@ end_latest_top_span(const TimestampTz *end_time, bool pop_span)
 }
 
 /*
- * Start a new top span if we've entered a new nested level or if the previous
- * span at the same level ended.
- */
-static void
-begin_top_span(pgTracingTraceContext * trace_context, Span * top_span,
-			   CmdType commandType, const Query *query, const JumbleState *jstate,
-			   const PlannedStmt *pstmt, const char *query_text, TimestampTz start_time)
-{
-	int			query_len;
-	const char *normalised_query;
-	uint64		parent_id;
-	int8		parent_planstate_index = -1;
-
-	/* in case of a cached plan, query might be unavailable */
-	if (query != NULL)
-		per_level_buffers[exec_nested_level].query_id = query->queryId;
-	else if (trace_context->query_id > 0)
-		per_level_buffers[exec_nested_level].query_id = trace_context->query_id;
-
-	if (exec_nested_level <= 0)
-		/* Root top span, use the parent id from the trace context */
-		parent_id = trace_context->traceparent.parent_id;
-	else
-	{
-		TracedPlanstate *parent_traced_planstate = NULL;
-		Span	   *latest_top_span = NULL;
-
-		/*
-		 * We're in a nested level, check if we have a parent planstate and
-		 * use it as a parent span
-		 */
-		parent_planstate_index = get_parent_traced_planstate_index(exec_nested_level);
-		if (parent_planstate_index > -1)
-			parent_traced_planstate = get_traced_planstate_from_index(parent_planstate_index);
-		latest_top_span = peek_nested_level_top_span(exec_nested_level - 1);
-
-		/*
-		 * Both planstate and previous top span can be the parent for the new
-		 * top span, we use the most recent as a parent
-		 */
-		if (parent_traced_planstate != NULL && parent_traced_planstate->node_start >= latest_top_span->start)
-			parent_id = parent_traced_planstate->span_id;
-		else
-			parent_id = latest_top_span->span_id;
-	}
-
-	begin_span(trace_context->traceparent.trace_id, top_span,
-			   command_type_to_span_type(commandType),
-			   NULL, parent_id,
-			   per_level_buffers[exec_nested_level].query_id, &start_time);
-	/* Keep track of the parent planstate index */
-	top_span->parent_planstate_index = parent_planstate_index;
-
-	if (IsParallelWorker())
-	{
-		/*
-		 * In a parallel worker, we use the worker name as the span's
-		 * operation
-		 */
-		top_span->operation_name_offset = add_worker_name_to_trace_buffer(current_trace_text, ParallelWorkerNumber);
-		return;
-	}
-
-	if (jstate && jstate->clocations_count > 0 && query != NULL)
-	{
-		/* jstate is available, normalise query and extract parameters' values */
-		char	   *param_str;
-		int			param_len;
-
-		query_len = query->stmt_len;
-		normalised_query = normalise_query_parameters(jstate, query_text,
-													  query->stmt_location, &query_len,
-													  &param_str, &param_len);
-		Assert(param_len > 0);
-		if (pg_tracing_export_parameters)
-			top_span->parameter_offset = add_str_to_trace_buffer(param_str, param_len);
-	}
-	else
-	{
-		/*
-		 * No jstate available, normalise query but we won't be able to
-		 * extract parameters
-		 */
-		int			stmt_location;
-
-		if (query != NULL && query->stmt_len > 0)
-		{
-			query_len = query->stmt_len;
-			stmt_location = query->stmt_location;
-		}
-		else if (pstmt != NULL && pstmt->stmt_location != -1 && pstmt->stmt_len > 0)
-		{
-			query_len = pstmt->stmt_len;
-			stmt_location = pstmt->stmt_location;
-		}
-		else
-		{
-			query_len = strlen(query_text);
-			stmt_location = 0;
-		}
-		normalised_query = normalise_query(query_text, stmt_location, &query_len);
-	}
-	if (query_len > 0)
-		top_span->operation_name_offset = add_str_to_trace_buffer(normalised_query,
-																  query_len);
-}
-
-/*
  * Initialise buffers if we are in a new nested level and start associated top span.
  * If the top span already exists for the current nested level, this has no effect.
  *
@@ -757,7 +635,7 @@ initialize_top_span(pgTracingTraceContext * trace_context, CmdType commandType,
 
 	/* This is a new top span, start it */
 	begin_top_span(trace_context, top_span, commandType, query, jstate, pstmt,
-				   query_text, start_time);
+				   query_text, start_time, pg_tracing_export_parameters);
 	return top_span->span_id;
 }
 

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -315,6 +315,11 @@ void
 			pop_top_span(void);
 Span	   *peek_top_span(void);
 Span	   *get_or_allocate_top_span(pgTracingTraceContext * trace_context, bool in_parse_or_plan);
+void
+begin_top_span(pgTracingTraceContext * trace_context, Span * top_span,
+			   CmdType commandType, const Query *query, const JumbleState *jstate,
+			   const PlannedStmt *pstmt, const char *query_text, TimestampTz start_time,
+               bool export_parameters);
 
 /* pg_tracing.c */
 extern MemoryContext pg_tracing_mem_ctx;

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -220,6 +220,21 @@ typedef struct pgTracingSpans
 	Span		spans[FLEXIBLE_ARRAY_MEMBER];
 }			pgTracingSpans;
 
+/*
+ * Structure to store per exec level informations
+ */
+typedef struct pgTracingPerLevelBuffer
+{
+	uint64		query_id;		/* Query id by for this level when available */
+	pgTracingSpans *top_spans;	/* top spans for the nested level */
+	uint64		executor_run_span_id;	/* executor run span id for this
+										 * level. Executor run is used as
+										 * parent for spans generated from
+										 * planstate */
+	TimestampTz executor_start;
+	TimestampTz executor_end;
+}			pgTracingPerLevelBuffer;
+
 /* pg_tracing_explain.c */
 extern const char *plan_to_node_type(const Plan *plan);
 extern const char *plan_to_operation(const planstateTraceContext * planstateTraceContext, const PlanState *planstate, const char *spanName);
@@ -293,10 +308,19 @@ extern bool traceid_zero(TraceId trace_id);
 /* pg_tracing_sql_functions.c */
 pgTracingStats get_empty_pg_tracing_stats(void);
 
+/* pg_tracing_top_spans.c */
+Span *
+get_latest_top_span(int nested_level);
+Span *
+allocate_new_top_span(void);
+void
+pop_top_span(void);
+
 /* pg_tracing.c */
 extern MemoryContext pg_tracing_mem_ctx;
 extern pgTracingSharedState * pg_tracing_shared_state;
 extern pgTracingSpans * shared_spans;
+extern pgTracingPerLevelBuffer * per_level_buffers;
 
 extern int	exec_nested_level;
 extern void

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -310,7 +310,6 @@ extern bool traceid_zero(TraceId trace_id);
 pgTracingStats get_empty_pg_tracing_stats(void);
 
 /* pg_tracing_top_spans.c */
-Span	   *peek_nested_level_top_span(int nested_level);
 Span	   *allocate_new_top_span(void);
 
 Span

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -309,20 +309,18 @@ extern bool traceid_zero(TraceId trace_id);
 /* pg_tracing_sql_functions.c */
 pgTracingStats get_empty_pg_tracing_stats(void);
 
-/* pg_tracing_top_spans.c */
-Span	   *allocate_new_top_span(void);
+/* pg_tracing_active_spans.c */
+Span	   *allocate_new_active_span(void);
 
-Span
-* pop_top_span(void);
-Span	   *peek_top_span(void);
-uint64
-			initialize_top_span(pgTracingTraceContext * trace_context, CmdType commandType,
-								Query *query, JumbleState *jstate, const PlannedStmt *pstmt,
-								const char *query_text, TimestampTz start_time,
-								bool in_parse_or_plan, bool export_parameters);
+Span	   *pop_active_span(void);
+Span	   *peek_active_span(void);
+uint64		initialize_active_span(pgTracingTraceContext * trace_context, CmdType commandType,
+									Query *query, JumbleState *jstate, const PlannedStmt *pstmt,
+									const char *query_text, TimestampTz start_time,
+									bool in_parse_or_plan, bool export_parameters);
 void
-			end_latest_top_span(const TimestampTz *end_time);
-void		cleanup_top_spans(void);
+			end_latest_active_span(const TimestampTz *end_time);
+void		cleanup_active_spans(void);
 
 /* pg_tracing.c */
 extern MemoryContext pg_tracing_mem_ctx;

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -316,11 +316,6 @@ Span
 * pop_top_span(void);
 Span	   *peek_top_span(void);
 Span	   *get_or_allocate_top_span(pgTracingTraceContext * trace_context, bool in_parse_or_plan);
-void
-			begin_top_span(pgTracingTraceContext * trace_context, Span * top_span,
-						   CmdType commandType, const Query *query, const JumbleState *jstate,
-						   const PlannedStmt *pstmt, const char *query_text, TimestampTz start_time,
-						   bool export_parameters);
 uint64
 			initialize_top_span(pgTracingTraceContext * trace_context, CmdType commandType,
 								Query *query, JumbleState *jstate, const PlannedStmt *pstmt,

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -210,6 +210,16 @@ typedef struct pgTracingParallelWorkers
 	pgTracingParallelContext trace_contexts[FLEXIBLE_ARRAY_MEMBER];
 }			pgTracingParallelWorkers;
 
+/*
+ * Structure to store flexible array of spans
+ */
+typedef struct pgTracingSpans
+{
+	int			end;			/* Index of last element */
+	int			max;			/* Maximum number of element */
+	Span		spans[FLEXIBLE_ARRAY_MEMBER];
+}			pgTracingSpans;
+
 /* pg_tracing_explain.c */
 extern const char *plan_to_node_type(const Plan *plan);
 extern const char *plan_to_operation(const planstateTraceContext * planstateTraceContext, const PlanState *planstate, const char *spanName);

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -107,8 +107,6 @@ typedef struct Span
 
 	SpanType	type;			/* Type of the span. Used to generate the
 								 * span's name */
-	bool		ended;			/* Track if the span was already ended.
-								 * Internal usage only */
 	int8		nested_level;	/* Nested level of this span this span.
 								 * Internal usage only */
 	int8		parent_planstate_index; /* Index to the parent planstate of

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -188,7 +188,7 @@ typedef struct pgTracingTraceContext
 {
 	pgTracingTraceparent traceparent;
 	uint64		query_id;		/* Query id of the current statement */
-	Span		root_span;		/* Top span for exec_nested_level 0 */
+	Span		root_span;		/* Top span for nested_level 0 */
 }			pgTracingTraceContext;
 
 /*
@@ -277,7 +277,7 @@ get_traced_planstate_from_index(int index);
 extern int
 			get_parent_traced_planstate_index(int nested_level);
 extern void
-			drop_traced_planstate(int exec_nested_level);
+			drop_traced_planstate(int nested_level);
 extern TimestampTz
 			get_span_end_from_planstate(PlanState *planstate, TimestampTz plan_start, TimestampTz root_end);
 
@@ -326,7 +326,7 @@ extern pgTracingSharedState * pg_tracing_shared_state;
 extern pgTracingSpans * shared_spans;
 extern pgTracingPerLevelBuffer * per_level_buffers;
 
-extern int	exec_nested_level;
+extern int	nested_level;
 extern int	max_nested_level;
 extern void
 			store_span(const Span * span);

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -313,9 +313,9 @@ Span	   *allocate_new_active_span(void);
 Span	   *pop_active_span(void);
 Span	   *peek_active_span(void);
 uint64		initialize_active_span(pgTracingTraceContext * trace_context, CmdType commandType,
-									Query *query, JumbleState *jstate, const PlannedStmt *pstmt,
-									const char *query_text, TimestampTz start_time,
-									bool in_parse_or_plan, bool export_parameters);
+								   Query *query, JumbleState *jstate, const PlannedStmt *pstmt,
+								   const char *query_text, TimestampTz start_time,
+								   bool in_parse_or_plan, bool export_parameters);
 void
 			end_latest_active_span(const TimestampTz *end_time);
 void		cleanup_active_spans(void);

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -228,7 +228,6 @@ typedef struct pgTracingSpans
 typedef struct pgTracingPerLevelBuffer
 {
 	uint64		query_id;		/* Query id by for this level when available */
-	pgTracingSpans *top_spans;	/* top spans for the nested level */
 	uint64		executor_run_span_id;	/* executor run span id for this
 										 * level. Executor run is used as
 										 * parent for spans generated from
@@ -313,8 +312,9 @@ pgTracingStats get_empty_pg_tracing_stats(void);
 /* pg_tracing_top_spans.c */
 Span	   *peek_nested_level_top_span(int nested_level);
 Span	   *allocate_new_top_span(void);
-void
-			pop_top_span(void);
+
+Span
+* pop_top_span(void);
 Span	   *peek_top_span(void);
 Span	   *get_or_allocate_top_span(pgTracingTraceContext * trace_context, bool in_parse_or_plan);
 void
@@ -328,7 +328,8 @@ uint64
 								const char *query_text, TimestampTz start_time,
 								bool in_parse_or_plan, bool export_parameters);
 void
-			end_latest_top_span(const TimestampTz *end_time, bool pop_span);
+			end_latest_top_span(const TimestampTz *end_time);
+void		cleanup_top_spans(void);
 
 /* pg_tracing.c */
 extern MemoryContext pg_tracing_mem_ctx;

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -309,14 +309,12 @@ extern bool traceid_zero(TraceId trace_id);
 pgTracingStats get_empty_pg_tracing_stats(void);
 
 /* pg_tracing_top_spans.c */
-Span *
-get_latest_top_span(int nested_level);
-Span *
-allocate_new_top_span(void);
+Span	   *peek_nested_level_top_span(int nested_level);
+Span	   *allocate_new_top_span(void);
 void
-pop_top_span(void);
-Span *
-peek_top_span(void);
+			pop_top_span(void);
+Span	   *peek_top_span(void);
+Span	   *get_or_allocate_top_span(pgTracingTraceContext * trace_context, bool in_parse_or_plan);
 
 /* pg_tracing.c */
 extern MemoryContext pg_tracing_mem_ctx;

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -315,7 +315,6 @@ Span	   *allocate_new_top_span(void);
 Span
 * pop_top_span(void);
 Span	   *peek_top_span(void);
-Span	   *get_or_allocate_top_span(pgTracingTraceContext * trace_context, bool in_parse_or_plan);
 uint64
 			initialize_top_span(pgTracingTraceContext * trace_context, CmdType commandType,
 								Query *query, JumbleState *jstate, const PlannedStmt *pstmt,

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -290,12 +290,22 @@ extern void adjust_file_offset(Span * span, Size file_position);
 extern bool traceid_zero(TraceId trace_id);
 
 
+/* pg_tracing_sql_functions.c */
+pgTracingStats get_empty_pg_tracing_stats(void);
+
 /* pg_tracing.c */
 extern MemoryContext pg_tracing_mem_ctx;
+extern pgTracingSharedState * pg_tracing_shared_state;
+extern pgTracingSpans * shared_spans;
+
 extern int	exec_nested_level;
 extern void
 			store_span(const Span * span);
 extern int
 			add_str_to_trace_buffer(const char *str, int str_len);
+extern void
+			cleanup_tracing(void);
+extern void
+			drop_all_spans_locked(void);
 
 #endif

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -316,10 +316,17 @@ void
 Span	   *peek_top_span(void);
 Span	   *get_or_allocate_top_span(pgTracingTraceContext * trace_context, bool in_parse_or_plan);
 void
-begin_top_span(pgTracingTraceContext * trace_context, Span * top_span,
-			   CmdType commandType, const Query *query, const JumbleState *jstate,
-			   const PlannedStmt *pstmt, const char *query_text, TimestampTz start_time,
-               bool export_parameters);
+			begin_top_span(pgTracingTraceContext * trace_context, Span * top_span,
+						   CmdType commandType, const Query *query, const JumbleState *jstate,
+						   const PlannedStmt *pstmt, const char *query_text, TimestampTz start_time,
+						   bool export_parameters);
+uint64
+			initialize_top_span(pgTracingTraceContext * trace_context, CmdType commandType,
+								Query *query, JumbleState *jstate, const PlannedStmt *pstmt,
+								const char *query_text, TimestampTz start_time,
+								bool in_parse_or_plan, bool export_parameters);
+void
+			end_latest_top_span(const TimestampTz *end_time, bool pop_span);
 
 /* pg_tracing.c */
 extern MemoryContext pg_tracing_mem_ctx;
@@ -328,6 +335,7 @@ extern pgTracingSpans * shared_spans;
 extern pgTracingPerLevelBuffer * per_level_buffers;
 
 extern int	exec_nested_level;
+extern int	max_nested_level;
 extern void
 			store_span(const Span * span);
 extern int

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -109,6 +109,8 @@ typedef struct Span
 								 * span's name */
 	bool		ended;			/* Track if the span was already ended.
 								 * Internal usage only */
+	int8		nested_level;	/* Nested level of this span this span.
+								 * Internal usage only */
 	int8		parent_planstate_index; /* Index to the parent planstate of
 										 * this span. Internal usage only */
 	int			be_pid;			/* Pid of the backend process */

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -315,6 +315,8 @@ Span *
 allocate_new_top_span(void);
 void
 pop_top_span(void);
+Span *
+peek_top_span(void);
 
 /* pg_tracing.c */
 extern MemoryContext pg_tracing_mem_ctx;

--- a/src/pg_tracing_active_spans.c
+++ b/src/pg_tracing_active_spans.c
@@ -58,8 +58,8 @@ allocate_new_active_span(void)
 		active_spans->max *= 2;
 		oldcxt = MemoryContextSwitchTo(pg_tracing_mem_ctx);
 		active_spans = repalloc0(active_spans,
-								  sizeof(pgTracingSpans) + old_spans_max * sizeof(Span),
-								  sizeof(pgTracingSpans) + old_spans_max * 2 * sizeof(Span));
+								 sizeof(pgTracingSpans) + old_spans_max * sizeof(Span),
+								 sizeof(pgTracingSpans) + old_spans_max * 2 * sizeof(Span));
 		MemoryContextSwitchTo(oldcxt);
 	}
 
@@ -99,9 +99,9 @@ pop_active_span(void)
  */
 static void
 begin_active_span(pgTracingTraceContext * trace_context, Span * top_span,
-				   CmdType commandType, const Query *query, const JumbleState *jstate,
-				   const PlannedStmt *pstmt, const char *query_text, TimestampTz start_time,
-				   bool export_parameters, Span * parent_span)
+				  CmdType commandType, const Query *query, const JumbleState *jstate,
+				  const PlannedStmt *pstmt, const char *query_text, TimestampTz start_time,
+				  bool export_parameters, Span * parent_span)
 {
 	int			query_len;
 	const char *normalised_query;
@@ -230,9 +230,9 @@ end_latest_active_span(const TimestampTz *end_time)
  */
 uint64
 initialize_active_span(pgTracingTraceContext * trace_context, CmdType commandType,
-						Query *query, JumbleState *jstate, const PlannedStmt *pstmt,
-						const char *query_text, TimestampTz start_time,
-						bool in_parse_or_plan, bool export_parameters)
+					   Query *query, JumbleState *jstate, const PlannedStmt *pstmt,
+					   const char *query_text, TimestampTz start_time,
+					   bool in_parse_or_plan, bool export_parameters)
 {
 	Span	   *span;
 	Span	   *parent_span;
@@ -272,6 +272,6 @@ initialize_active_span(pgTracingTraceContext * trace_context, CmdType commandTyp
 
 	/* This is a new top span, start it */
 	begin_active_span(trace_context, span, commandType, query, jstate, pstmt,
-					   query_text, start_time, export_parameters, parent_span);
+					  query_text, start_time, export_parameters, parent_span);
 	return span->span_id;
 }

--- a/src/pg_tracing_planstate.c
+++ b/src/pg_tracing_planstate.c
@@ -44,14 +44,14 @@ cleanup_planstarts(void)
  * Drop all traced_planstates after the provided nested level
  */
 void
-drop_traced_planstate(int exec_nested_level)
+drop_traced_planstate(int level)
 {
 	int			i;
 	int			new_index_start = 0;
 
 	for (i = index_planstart; i > 0; i--)
 	{
-		if (traced_planstates[i - 1].nested_level <= exec_nested_level)
+		if (traced_planstates[i - 1].nested_level <= level)
 		{
 			/*
 			 * Found a new planstate from a previous nested level, we can stop
@@ -104,7 +104,7 @@ ExecProcNodeFirstPgTracing(PlanState *node)
 	traced_planstates[index_planstart].planstate = node;
 	traced_planstates[index_planstart].node_start = GetCurrentTimestamp();
 	traced_planstates[index_planstart].span_id = pg_prng_uint64(&pg_global_prng_state);
-	traced_planstates[index_planstart].nested_level = exec_nested_level;
+	traced_planstates[index_planstart].nested_level = nested_level;
 	index_planstart++;
 
 exit:

--- a/src/pg_tracing_span.c
+++ b/src/pg_tracing_span.c
@@ -77,7 +77,6 @@ initialize_span_fields(Span * span, SpanType type, TraceId trace_id, uint64 *spa
 	span->database_id = MyDatabaseId;
 	span->user_id = GetUserId();
 	span->subxact_count = MyProc->subxidStatus.count;
-	span->ended = false;
 	span->query_id = query_id;
 	memset(&span->node_counters, 0, sizeof(NodeCounters));
 	memset(&span->plan_counters, 0, sizeof(PlanCounters));
@@ -126,10 +125,6 @@ end_span(Span * span, const TimestampTz *end_time_input)
 	WalUsage	wal_usage;
 
 	Assert(!traceid_zero(span->trace_id));
-
-	/* Span should be ended only once */
-	Assert(!span->ended);
-	span->ended = true;
 
 	/* Set span duration with the end time before subtracting the start */
 	if (end_time_input == NULL)

--- a/src/pg_tracing_span.c
+++ b/src/pg_tracing_span.c
@@ -72,7 +72,6 @@ initialize_span_fields(Span * span, SpanType type, TraceId trace_id, uint64 *spa
 	span->deparse_info_offset = -1;
 	span->sql_error_code = 0;
 	span->startup = 0;
-	span->nested_level = exec_nested_level;
 	span->be_pid = MyProcPid;
 	span->database_id = MyDatabaseId;
 	span->user_id = GetUserId();

--- a/src/pg_tracing_span.c
+++ b/src/pg_tracing_span.c
@@ -72,6 +72,7 @@ initialize_span_fields(Span * span, SpanType type, TraceId trace_id, uint64 *spa
 	span->deparse_info_offset = -1;
 	span->sql_error_code = 0;
 	span->startup = 0;
+	span->nested_level = exec_nested_level;
 	span->be_pid = MyProcPid;
 	span->database_id = MyDatabaseId;
 	span->user_id = GetUserId();

--- a/src/pg_tracing_sql_functions.c
+++ b/src/pg_tracing_sql_functions.c
@@ -1,0 +1,322 @@
+/*-------------------------------------------------------------------------
+ *
+ * pg_tracing_sql_functions.c
+ * 		sql functions used by pg_tracing
+ *
+ * IDENTIFICATION
+ *	  src/pg_tracing_sql_functions.c
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "postgres.h"
+
+#include "funcapi.h"
+#include "pg_tracing.h"
+#include "utils/builtins.h"
+#include "utils/fmgrprotos.h"
+#include "utils/timestamp.h"
+
+#define INT64_HEX_FORMAT "%016" INT64_MODIFIER "x"
+
+PG_FUNCTION_INFO_V1(pg_tracing_info);
+PG_FUNCTION_INFO_V1(pg_tracing_spans);
+PG_FUNCTION_INFO_V1(pg_tracing_reset);
+
+/*
+ * Get an empty pgTracingStats
+ */
+pgTracingStats
+get_empty_pg_tracing_stats(void)
+{
+	pgTracingStats stats;
+
+	stats.processed_traces = 0;
+	stats.processed_spans = 0;
+	stats.dropped_traces = 0;
+	stats.dropped_spans = 0;
+	stats.last_consume = 0;
+	stats.stats_reset = GetCurrentTimestamp();
+	return stats;
+}
+
+/*
+ * Add plan counters to the Datum output
+ */
+static int
+add_plan_counters(const PlanCounters * plan_counters, int i, Datum *values)
+{
+	values[i++] = Float8GetDatumFast(plan_counters->startup_cost);
+	values[i++] = Float8GetDatumFast(plan_counters->total_cost);
+	values[i++] = Float8GetDatumFast(plan_counters->plan_rows);
+	values[i++] = Int32GetDatum(plan_counters->plan_width);
+	return i;
+}
+
+/*
+ * Add node counters to the Datum output
+ */
+static int
+add_node_counters(const NodeCounters * node_counters, int i, Datum *values)
+{
+	Datum		wal_bytes;
+	char		buf[256];
+	double		blk_read_time,
+				blk_write_time,
+				temp_blk_read_time,
+				temp_blk_write_time;
+	double		generation_counter,
+				inlining_counter,
+				optimization_counter,
+				emission_counter;
+	int64		jit_created_functions;
+
+	values[i++] = Int64GetDatumFast(node_counters->rows);
+	values[i++] = Int64GetDatumFast(node_counters->nloops);
+
+	/* Buffer usage */
+	values[i++] = Int64GetDatumFast(node_counters->buffer_usage.shared_blks_hit);
+	values[i++] = Int64GetDatumFast(node_counters->buffer_usage.shared_blks_read);
+	values[i++] = Int64GetDatumFast(node_counters->buffer_usage.shared_blks_dirtied);
+	values[i++] = Int64GetDatumFast(node_counters->buffer_usage.shared_blks_written);
+
+	values[i++] = Int64GetDatumFast(node_counters->buffer_usage.local_blks_hit);
+	values[i++] = Int64GetDatumFast(node_counters->buffer_usage.local_blks_read);
+	values[i++] = Int64GetDatumFast(node_counters->buffer_usage.local_blks_dirtied);
+	values[i++] = Int64GetDatumFast(node_counters->buffer_usage.local_blks_written);
+
+#if PG_VERSION_NUM >= 170000
+	blk_read_time = INSTR_TIME_GET_MILLISEC(node_counters->buffer_usage.shared_blk_read_time);
+	blk_write_time = INSTR_TIME_GET_MILLISEC(node_counters->buffer_usage.shared_blk_write_time);
+#else
+	blk_read_time = INSTR_TIME_GET_MILLISEC(node_counters->buffer_usage.blk_read_time);
+	blk_write_time = INSTR_TIME_GET_MILLISEC(node_counters->buffer_usage.blk_write_time);
+#endif
+
+	temp_blk_read_time = INSTR_TIME_GET_MILLISEC(node_counters->buffer_usage.temp_blk_read_time);
+	temp_blk_write_time = INSTR_TIME_GET_MILLISEC(node_counters->buffer_usage.temp_blk_write_time);
+
+	values[i++] = Float8GetDatumFast(blk_read_time);
+	values[i++] = Float8GetDatumFast(blk_write_time);
+	values[i++] = Float8GetDatumFast(temp_blk_read_time);
+	values[i++] = Float8GetDatumFast(temp_blk_write_time);
+
+	values[i++] = Int64GetDatumFast(node_counters->buffer_usage.temp_blks_read);
+	values[i++] = Int64GetDatumFast(node_counters->buffer_usage.temp_blks_written);
+
+	/* WAL usage */
+	values[i++] = Int64GetDatumFast(node_counters->wal_usage.wal_records);
+	values[i++] = Int64GetDatumFast(node_counters->wal_usage.wal_fpi);
+	snprintf(buf, sizeof buf, UINT64_FORMAT, node_counters->wal_usage.wal_bytes);
+
+	/* Convert to numeric. */
+	wal_bytes = DirectFunctionCall3(numeric_in,
+									CStringGetDatum(buf),
+									ObjectIdGetDatum(0),
+									Int32GetDatum(-1));
+	values[i++] = wal_bytes;
+
+	/* JIT usage */
+	generation_counter = INSTR_TIME_GET_MILLISEC(node_counters->jit_usage.generation_counter);
+	inlining_counter = INSTR_TIME_GET_MILLISEC(node_counters->jit_usage.inlining_counter);
+	optimization_counter = INSTR_TIME_GET_MILLISEC(node_counters->jit_usage.optimization_counter);
+	emission_counter = INSTR_TIME_GET_MILLISEC(node_counters->jit_usage.emission_counter);
+	jit_created_functions = node_counters->jit_usage.created_functions;
+
+	values[i++] = Int64GetDatumFast(jit_created_functions);
+	values[i++] = Float8GetDatumFast(generation_counter);
+	values[i++] = Float8GetDatumFast(inlining_counter);
+	values[i++] = Float8GetDatumFast(optimization_counter);
+	values[i++] = Float8GetDatumFast(emission_counter);
+
+	return i;
+}
+
+/*
+ * Build the tuple for a Span and add it to the output
+ */
+static void
+add_result_span(ReturnSetInfo *rsinfo, Span * span,
+				const char *qbuffer, Size qbuffer_size)
+{
+#define PG_TRACING_TRACES_COLS	44
+	Datum		values[PG_TRACING_TRACES_COLS] = {0};
+	bool		nulls[PG_TRACING_TRACES_COLS] = {0};
+	const char *span_type;
+	const char *operation_name;
+	const char *sql_error_code;
+	int			i = 0;
+	char		trace_id[33];
+	char		parent_id[17];
+	char		span_id[17];
+
+	span_type = get_span_type(span, qbuffer, qbuffer_size);
+	operation_name = get_operation_name(span, qbuffer, qbuffer_size);
+	sql_error_code = unpack_sql_state(span->sql_error_code);
+
+	pg_snprintf(trace_id, 33, INT64_HEX_FORMAT INT64_HEX_FORMAT,
+				span->trace_id.traceid_left,
+				span->trace_id.traceid_right);
+	pg_snprintf(parent_id, 17, INT64_HEX_FORMAT, span->parent_id);
+	pg_snprintf(span_id, 17, INT64_HEX_FORMAT, span->span_id);
+
+	Assert(span_type != NULL);
+	Assert(operation_name != NULL);
+	Assert(sql_error_code != NULL);
+
+	values[i++] = CStringGetTextDatum(trace_id);
+	values[i++] = CStringGetTextDatum(parent_id);
+	values[i++] = CStringGetTextDatum(span_id);
+	values[i++] = UInt64GetDatum(span->query_id);
+	values[i++] = CStringGetTextDatum(span_type);
+	values[i++] = CStringGetTextDatum(operation_name);
+	values[i++] = Int64GetDatumFast(span->start);
+	values[i++] = Int64GetDatumFast(span->end);
+
+	values[i++] = CStringGetTextDatum(sql_error_code);
+	values[i++] = UInt32GetDatum(span->be_pid);
+	values[i++] = ObjectIdGetDatum(span->user_id);
+	values[i++] = ObjectIdGetDatum(span->database_id);
+	values[i++] = UInt8GetDatum(span->subxact_count);
+
+	/* Only node and top spans have counters */
+	if ((span->type >= SPAN_NODE && span->type <= SPAN_TOP_UNKNOWN)
+		|| span->type == SPAN_PLANNER)
+	{
+		i = add_plan_counters(&span->plan_counters, i, values);
+		i = add_node_counters(&span->node_counters, i, values);
+		values[i++] = Int64GetDatumFast(span->startup);
+
+		if (span->parameter_offset != -1 && qbuffer_size > 0 && qbuffer_size > span->parameter_offset)
+			values[i++] = CStringGetTextDatum(qbuffer + span->parameter_offset);
+		else
+			nulls[i++] = 1;
+
+		if (span->deparse_info_offset != -1 && qbuffer_size > 0 && qbuffer_size > span->deparse_info_offset)
+			values[i++] = CStringGetTextDatum(qbuffer + span->deparse_info_offset);
+	}
+
+	for (int j = i; j < PG_TRACING_TRACES_COLS; j++)
+		nulls[j] = 1;
+
+	tuplestore_putvalues(rsinfo->setResult, rsinfo->setDesc, values, nulls);
+}
+
+/*
+ * Return spans as a result set.
+ *
+ * Accept a consume parameter. When consume is set,
+ * we empty the shared buffer and truncate query text.
+ */
+Datum
+pg_tracing_spans(PG_FUNCTION_ARGS)
+{
+	bool		consume;
+	ReturnSetInfo *rsinfo = (ReturnSetInfo *) fcinfo->resultinfo;
+	Span	   *span;
+	const char *qbuffer;
+	Size		qbuffer_size = 0;
+	LWLockMode	lock_mode = LW_SHARED;
+
+	consume = PG_GETARG_BOOL(0);
+
+	/*
+	 * We need an exclusive lock to truncate and empty the shared buffer when
+	 * we consume
+	 */
+	if (consume)
+		lock_mode = LW_EXCLUSIVE;
+
+	if (!pg_tracing_shared_state)
+		ereport(ERROR,
+				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+				 errmsg("pg_tracing must be loaded via shared_preload_libraries")));
+	InitMaterializedSRF(fcinfo, 0);
+
+	/*
+	 * If this query was sampled and we're consuming tracing_spans buffer, the
+	 * spans will target a query string that doesn't exist anymore in the
+	 * query file. Better abort the sampling and clean ongoing traces. Since
+	 * this will be called within an ExecutorRun, we will need to check for
+	 * current_trace_spans at the end of the ExecutorRun hook.
+	 */
+	cleanup_tracing();
+
+	qbuffer = qtext_load_file(&qbuffer_size);
+	if (qbuffer == NULL)
+
+		/*
+		 * It's possible to get NULL if file was truncated while we read it.
+		 * Abort in this case.
+		 */
+		return (Datum) 0;
+
+	LWLockAcquire(pg_tracing_shared_state->lock, lock_mode);
+	for (int i = 0; i < shared_spans->end; i++)
+	{
+		span = shared_spans->spans + i;
+		add_result_span(rsinfo, span, qbuffer, qbuffer_size);
+	}
+
+	/* Consume is set, remove spans from the shared buffer */
+	if (consume)
+		drop_all_spans_locked();
+	pg_tracing_shared_state->stats.last_consume = GetCurrentTimestamp();
+	LWLockRelease(pg_tracing_shared_state->lock);
+
+	return (Datum) 0;
+}
+
+/*
+ * Return statistics of pg_tracing.
+ */
+Datum
+pg_tracing_info(PG_FUNCTION_ARGS)
+{
+#define PG_TRACING_INFO_COLS	6
+	pgTracingStats stats;
+	TupleDesc	tupdesc;
+	Datum		values[PG_TRACING_INFO_COLS] = {0};
+	bool		nulls[PG_TRACING_INFO_COLS] = {0};
+	int			i = 0;
+
+	if (!pg_tracing_shared_state)
+		ereport(ERROR,
+				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+				 errmsg("pg_tracing must be loaded via shared_preload_libraries")));
+
+	/* Build a tuple descriptor for our result type */
+	if (get_call_result_type(fcinfo, NULL, &tupdesc) != TYPEFUNC_COMPOSITE)
+		elog(ERROR, "return type must be a row type");
+
+	/* Get a copy of the pg_tracing stats */
+	LWLockAcquire(pg_tracing_shared_state->lock, LW_SHARED);
+	stats = pg_tracing_shared_state->stats;
+	LWLockRelease(pg_tracing_shared_state->lock);
+
+	values[i++] = Int64GetDatum(stats.processed_traces);
+	values[i++] = Int64GetDatum(stats.processed_spans);
+	values[i++] = Int64GetDatum(stats.dropped_traces);
+	values[i++] = Int64GetDatum(stats.dropped_spans);
+	values[i++] = TimestampTzGetDatum(stats.last_consume);
+	values[i++] = TimestampTzGetDatum(stats.stats_reset);
+
+	PG_RETURN_DATUM(HeapTupleGetDatum(heap_form_tuple(tupdesc, values, nulls)));
+}
+
+/*
+ * Reset pg_tracing statistics.
+ */
+Datum
+pg_tracing_reset(PG_FUNCTION_ARGS)
+{
+	/*
+	 * Reset statistics for pg_tracing since all entries are removed.
+	 */
+	pgTracingStats empty_stats = get_empty_pg_tracing_stats();
+
+	LWLockAcquire(pg_tracing_shared_state->lock, LW_EXCLUSIVE);
+	pg_tracing_shared_state->stats = empty_stats;
+	LWLockRelease(pg_tracing_shared_state->lock);
+
+	PG_RETURN_VOID();
+}

--- a/src/pg_tracing_top_spans.c
+++ b/src/pg_tracing_top_spans.c
@@ -11,6 +11,7 @@
 #include "postgres.h"
 
 #include "pg_tracing.h"
+#include "access/parallel.h"
 
 
 /*
@@ -113,4 +114,123 @@ pop_top_span(void)
 	Assert(top_spans->end > 0);
 	/* Reset span id of the discarded span since it could be reused */
 	top_spans->spans[--top_spans->end].span_id = 0;
+}
+
+/*
+ * Add the worker name to the provided stringinfo
+ */
+static int
+add_worker_name_to_trace_buffer(int parallel_worker_number)
+{
+    char *worker_name = psprintf("Worker %d", parallel_worker_number);
+	return add_str_to_trace_buffer(worker_name, strlen(worker_name));
+}
+
+/*
+ * Start a new top span if we've entered a new nested level or if the previous
+ * span at the same level ended.
+ */
+void
+begin_top_span(pgTracingTraceContext * trace_context, Span * top_span,
+			   CmdType commandType, const Query *query, const JumbleState *jstate,
+			   const PlannedStmt *pstmt, const char *query_text, TimestampTz start_time,
+               bool export_parameters)
+{
+	int			query_len;
+	const char *normalised_query;
+	uint64		parent_id;
+	int8		parent_planstate_index = -1;
+
+	/* in case of a cached plan, query might be unavailable */
+	if (query != NULL)
+		per_level_buffers[exec_nested_level].query_id = query->queryId;
+	else if (trace_context->query_id > 0)
+		per_level_buffers[exec_nested_level].query_id = trace_context->query_id;
+
+	if (exec_nested_level <= 0)
+		/* Root top span, use the parent id from the trace context */
+		parent_id = trace_context->traceparent.parent_id;
+	else
+	{
+		TracedPlanstate *parent_traced_planstate = NULL;
+		Span	   *latest_top_span = NULL;
+
+		/*
+		 * We're in a nested level, check if we have a parent planstate and
+		 * use it as a parent span
+		 */
+		parent_planstate_index = get_parent_traced_planstate_index(exec_nested_level);
+		if (parent_planstate_index > -1)
+			parent_traced_planstate = get_traced_planstate_from_index(parent_planstate_index);
+		latest_top_span = peek_nested_level_top_span(exec_nested_level - 1);
+
+		/*
+		 * Both planstate and previous top span can be the parent for the new
+		 * top span, we use the most recent as a parent
+		 */
+		if (parent_traced_planstate != NULL && parent_traced_planstate->node_start >= latest_top_span->start)
+			parent_id = parent_traced_planstate->span_id;
+		else
+			parent_id = latest_top_span->span_id;
+	}
+
+	begin_span(trace_context->traceparent.trace_id, top_span,
+			   command_type_to_span_type(commandType),
+			   NULL, parent_id,
+			   per_level_buffers[exec_nested_level].query_id, &start_time);
+	/* Keep track of the parent planstate index */
+	top_span->parent_planstate_index = parent_planstate_index;
+
+	if (IsParallelWorker())
+	{
+		/*
+		 * In a parallel worker, we use the worker name as the span's
+		 * operation
+		 */
+		top_span->operation_name_offset = add_worker_name_to_trace_buffer(ParallelWorkerNumber);
+		return;
+	}
+
+	if (jstate && jstate->clocations_count > 0 && query != NULL)
+	{
+		/* jstate is available, normalise query and extract parameters' values */
+		char	   *param_str;
+		int			param_len;
+
+		query_len = query->stmt_len;
+		normalised_query = normalise_query_parameters(jstate, query_text,
+													  query->stmt_location, &query_len,
+													  &param_str, &param_len);
+		Assert(param_len > 0);
+		if (export_parameters)
+			top_span->parameter_offset = add_str_to_trace_buffer(param_str, param_len);
+	}
+	else
+	{
+		/*
+		 * No jstate available, normalise query but we won't be able to
+		 * extract parameters
+		 */
+		int			stmt_location;
+
+		if (query != NULL && query->stmt_len > 0)
+		{
+			query_len = query->stmt_len;
+			stmt_location = query->stmt_location;
+		}
+		else if (pstmt != NULL && pstmt->stmt_location != -1 && pstmt->stmt_len > 0)
+		{
+			query_len = pstmt->stmt_len;
+			stmt_location = pstmt->stmt_location;
+		}
+		else
+		{
+			query_len = strlen(query_text);
+			stmt_location = 0;
+		}
+		normalised_query = normalise_query(query_text, stmt_location, &query_len);
+	}
+	if (query_len > 0)
+		top_span->operation_name_offset = add_str_to_trace_buffer(normalised_query,
+																  query_len);
 }

--- a/src/pg_tracing_top_spans.c
+++ b/src/pg_tracing_top_spans.c
@@ -14,20 +14,6 @@
 
 
 /*
- * Get the latest span for a specific level. The span must exists
- */
-Span *
-get_latest_top_span(int nested_level)
-{
-	pgTracingSpans *top_spans;
-
-	Assert(nested_level >= 0);
-	top_spans = per_level_buffers[nested_level].top_spans;
-	Assert(top_spans->end > 0);
-	return &top_spans->spans[top_spans->end - 1];
-}
-
-/*
  * Create a new top_span for the current exec nested level
  */
 Span *
@@ -56,6 +42,40 @@ allocate_new_top_span(void)
 }
 
 /*
+ * Get the ongoing top span if it exists or create it
+ */
+Span *
+get_or_allocate_top_span(pgTracingTraceContext * trace_context, bool in_parse_or_plan)
+{
+	Span	   *span;
+
+	if (in_parse_or_plan && exec_nested_level == 0)
+
+		/*
+		 * The root post parse and plan, we want to use trace_context's
+		 * root_span as the top span in per_level_buffers might still be
+		 * ongoing.
+		 */
+		return &trace_context->root_span;
+
+	if (per_level_buffers[exec_nested_level].top_spans->end == 0)
+		/* No spans were created in this level, allocate a new one */
+		span = allocate_new_top_span();
+	else
+		span = peek_top_span();
+
+	if (exec_nested_level == 0)
+
+		/*
+		 * At root level and outside of parse/plan hook, we need to copy the
+		 * root span content
+		 */
+		*span = trace_context->root_span;
+
+	return span;
+}
+
+/*
  * Get the latest top span
  */
 Span *
@@ -64,6 +84,20 @@ peek_top_span(void)
 	pgTracingSpans *top_spans;
 
 	top_spans = per_level_buffers[exec_nested_level].top_spans;
+	Assert(top_spans->end > 0);
+	return &top_spans->spans[top_spans->end - 1];
+}
+
+/*
+ * Get the latest span for a specific level. The span must exists
+ */
+Span *
+peek_nested_level_top_span(int nested_level)
+{
+	pgTracingSpans *top_spans;
+
+	Assert(nested_level >= 0);
+	top_spans = per_level_buffers[nested_level].top_spans;
 	Assert(top_spans->end > 0);
 	return &top_spans->spans[top_spans->end - 1];
 }

--- a/src/pg_tracing_top_spans.c
+++ b/src/pg_tracing_top_spans.c
@@ -256,12 +256,9 @@ end_latest_top_span(const TimestampTz *end_time)
 	if (exec_nested_level > max_nested_level)
 		return;
 
-	top_span = peek_top_span();
+	top_span = pop_top_span();
 	end_span(top_span, end_time);
 	store_span(top_span);
-
-	/* Restore previous top span */
-	pop_top_span();
 }
 
 /*

--- a/src/pg_tracing_top_spans.c
+++ b/src/pg_tracing_top_spans.c
@@ -283,7 +283,9 @@ initialize_top_span(pgTracingTraceContext * trace_context, CmdType commandType,
 	top_span = get_or_allocate_top_span(trace_context, in_parse_or_plan);
 
 	/* If the top_span is still ongoing, use it as it is */
-	if (top_span->span_id > 0 && top_span->ended == false)
+	if (top_span->nested_level == exec_nested_level
+		&& top_span->span_id > 0
+		&& top_span->ended == false)
 		return top_span->span_id;
 
 	if (top_span->span_id > 0)

--- a/src/pg_tracing_top_spans.c
+++ b/src/pg_tracing_top_spans.c
@@ -56,6 +56,19 @@ allocate_new_top_span(void)
 }
 
 /*
+ * Get the latest top span
+ */
+Span *
+peek_top_span(void)
+{
+	pgTracingSpans *top_spans;
+
+	top_spans = per_level_buffers[exec_nested_level].top_spans;
+	Assert(top_spans->end > 0);
+	return &top_spans->spans[top_spans->end - 1];
+}
+
+/*
  * Drop the latest top span for the current nested level
  */
 void

--- a/src/pg_tracing_top_spans.c
+++ b/src/pg_tracing_top_spans.c
@@ -38,6 +38,8 @@ cleanup_top_spans(void)
 Span *
 allocate_new_top_span(void)
 {
+	Span	   *top_span;
+
 	if (top_spans == NULL)
 	{
 		MemoryContext oldcxt;
@@ -61,7 +63,9 @@ allocate_new_top_span(void)
 		MemoryContextSwitchTo(oldcxt);
 	}
 
-	return &top_spans->spans[top_spans->end++];
+	top_span = &top_spans->spans[top_spans->end++];
+	top_span->nested_level = exec_nested_level;
+	return top_span;
 }
 
 /*

--- a/src/pg_tracing_top_spans.c
+++ b/src/pg_tracing_top_spans.c
@@ -71,7 +71,7 @@ allocate_new_top_span(void)
 /*
  * Get the ongoing top span if it exists or create it
  */
-Span *
+static Span *
 get_or_allocate_top_span(pgTracingTraceContext * trace_context, bool in_parse_or_plan)
 {
 	Span	   *span;
@@ -282,13 +282,6 @@ initialize_top_span(pgTracingTraceContext * trace_context, CmdType commandType,
 		&& top_span->span_id > 0
 		&& top_span->ended == false)
 		return top_span->span_id;
-
-	if (top_span->span_id > 0)
-	{
-		/* The previous top span was closed, create a new one */
-		Assert(top_span->ended);
-		top_span = allocate_new_top_span();
-	}
 
 	/* This is a new top span, start it */
 	begin_top_span(trace_context, top_span, commandType, query, jstate, pstmt,

--- a/src/pg_tracing_top_spans.c
+++ b/src/pg_tracing_top_spans.c
@@ -104,7 +104,7 @@ get_or_allocate_top_span(pgTracingTraceContext * trace_context, bool in_parse_or
 Span *
 peek_top_span(void)
 {
-	if (top_spans->end == 0)
+	if (top_spans == NULL || top_spans->end == 0)
 		return NULL;
 	return &top_spans->spans[top_spans->end - 1];
 }
@@ -126,7 +126,7 @@ peek_nested_level_top_span(int nested_level)
 Span *
 pop_top_span(void)
 {
-	if (top_spans->end == 0)
+	if (top_spans == NULL || top_spans->end == 0)
 		return NULL;
 
 	Assert(top_spans->end > 0);

--- a/src/pg_tracing_top_spans.c
+++ b/src/pg_tracing_top_spans.c
@@ -116,12 +116,20 @@ peek_top_span(void)
 /*
  * Get the latest span for a specific level. The span must exists
  */
-Span *
+static Span *
 peek_nested_level_top_span(int nested_level)
 {
+	Span	   *top_span = NULL;
+
 	Assert(nested_level >= 0);
 	Assert(top_spans->end > 0);
-	return &top_spans->spans[top_spans->end - 1];
+	for (int i = 0; i < top_spans->end; i++)
+	{
+		if (top_spans->spans[i].nested_level > nested_level)
+			return top_span;
+		top_span = &top_spans->spans[i];
+	}
+	return NULL;
 }
 
 /*

--- a/src/pg_tracing_top_spans.c
+++ b/src/pg_tracing_top_spans.c
@@ -1,0 +1,69 @@
+/*-------------------------------------------------------------------------
+ *
+ * pg_tracing_top_spans.c
+ * 		functions managing top_spans.
+ *
+ * IDENTIFICATION
+ *	  src/pg_tracing_top_spans.c
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "postgres.h"
+
+#include "pg_tracing.h"
+
+
+/*
+ * Get the latest span for a specific level. The span must exists
+ */
+Span *
+get_latest_top_span(int nested_level)
+{
+	pgTracingSpans *top_spans;
+
+	Assert(nested_level >= 0);
+	top_spans = per_level_buffers[nested_level].top_spans;
+	Assert(top_spans->end > 0);
+	return &top_spans->spans[top_spans->end - 1];
+}
+
+/*
+ * Create a new top_span for the current exec nested level
+ */
+Span *
+allocate_new_top_span(void)
+{
+	pgTracingSpans *top_spans;
+	Span	   *top_span;
+
+	top_spans = per_level_buffers[exec_nested_level].top_spans;
+	if (top_spans->end >= top_spans->max)
+	{
+		MemoryContext oldcxt;
+		int			old_spans_max = top_spans->max;
+
+		top_spans->max *= 2;
+		oldcxt = MemoryContextSwitchTo(pg_tracing_mem_ctx);
+		top_spans = repalloc0(top_spans,
+							  sizeof(pgTracingSpans) + old_spans_max * sizeof(Span),
+							  sizeof(pgTracingSpans) + old_spans_max * 2 * sizeof(Span));
+		per_level_buffers[exec_nested_level].top_spans = top_spans;
+		MemoryContextSwitchTo(oldcxt);
+	}
+	top_span = &top_spans->spans[top_spans->end++];
+	Assert(top_span->span_id == 0);
+	return top_span;
+}
+
+/*
+ * Drop the latest top span for the current nested level
+ */
+void
+pop_top_span(void)
+{
+	pgTracingSpans *top_spans = per_level_buffers[exec_nested_level].top_spans;
+
+	Assert(top_spans->end > 0);
+	/* Reset span id of the discarded span since it could be reused */
+	top_spans->spans[--top_spans->end].span_id = 0;
+}


### PR DESCRIPTION
Remove top_spans from per_level_buffers and now keep a stack of active spans. 
The active spans stack only keep ongoing spans that can be used s parent. Once finished, they will be moved to current_trace_spans.
Removed plan_nested_level and renamed exec_nested_level to nested_level. 