### PR TITLE
Remove root span and max_nested_level

### DIFF
--- a/src/pg_tracing.c
+++ b/src/pg_tracing.c
@@ -1845,11 +1845,12 @@ pg_tracing_xact_callback(XactEvent event, void *arg)
 			store_span(&commit_span);
 
 			end_tracing(trace_context);
-			commit_span.span_id = 0;
+			reset_span(&commit_span);
 			break;
 		case XACT_EVENT_ABORT:
+			/* TODO: Create an abort span */
 			end_tracing(trace_context);
-			commit_span.span_id = 0;
+			reset_span(&commit_span);
 		default:
 			break;
 	}

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -297,7 +297,6 @@ extern const char *qtext_load_file(Size *buffer_size);
 extern void begin_span(TraceId trace_id, Span * span,
 					   SpanType type, uint64 *span_id, uint64 parent_id, uint64 query_id, const TimestampTz *start_span);
 extern void end_span(Span * span, const TimestampTz *end_time);
-extern SpanType command_type_to_span_type(CmdType cmd_type);
 extern const char *get_span_type(const Span * span, const char *qbuffer, Size qbuffer_size);
 extern const char *get_operation_name(const Span * span, const char *qbuffer, Size qbuffer_size);
 extern void adjust_file_offset(Span * span, Size file_position);

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -327,7 +327,6 @@ extern pgTracingSpans * shared_spans;
 extern pgTracingPerLevelBuffer * per_level_buffers;
 
 extern int	nested_level;
-extern int	max_nested_level;
 extern void
 			store_span(const Span * span);
 extern int

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -297,6 +297,7 @@ extern const char *qtext_load_file(Size *buffer_size);
 extern void begin_span(TraceId trace_id, Span * span,
 					   SpanType type, uint64 *span_id, uint64 parent_id, uint64 query_id, const TimestampTz *start_span);
 extern void end_span(Span * span, const TimestampTz *end_time);
+extern void reset_span(Span * span);
 extern const char *get_span_type(const Span * span, const char *qbuffer, Size qbuffer_size);
 extern const char *get_operation_name(const Span * span, const char *qbuffer, Size qbuffer_size);
 extern void adjust_file_offset(Span * span, Size file_position);

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -46,6 +46,16 @@ typedef struct PlanCounters
 }			PlanCounters;
 
 /*
+ * Hook currently called
+ */
+typedef enum HookPhase
+{
+	HOOK_PARSE,
+	HOOK_PLANNER,
+	HOOK_EXECUTOR,
+}			HookPhase;
+
+/*
  * SpanType: Type of the span
  */
 typedef enum SpanType
@@ -188,7 +198,6 @@ typedef struct pgTracingTraceContext
 {
 	pgTracingTraceparent traceparent;
 	uint64		query_id;		/* Query id of the current statement */
-	Span		root_span;		/* Top span for nested_level 0 */
 }			pgTracingTraceContext;
 
 /*
@@ -315,7 +324,7 @@ Span	   *peek_active_span(void);
 uint64		initialize_active_span(pgTracingTraceContext * trace_context, CmdType commandType,
 								   Query *query, JumbleState *jstate, const PlannedStmt *pstmt,
 								   const char *query_text, TimestampTz start_time,
-								   bool in_parse_or_plan, bool export_parameters);
+								   HookPhase hook_phase, bool export_parameters);
 void
 			end_latest_active_span(const TimestampTz *end_time);
 void		cleanup_active_spans(void);

--- a/src/pg_tracing_active_spans.c
+++ b/src/pg_tracing_active_spans.c
@@ -13,7 +13,15 @@
 #include "pg_tracing.h"
 #include "access/parallel.h"
 
+/* Stack of active spans */
 static pgTracingSpans * active_spans = NULL;
+
+/*
+ * Active parse for the next statement. Used to deal with extended
+ * protocol parsing the next statement while tracing of the previous
+ * statement is still ongoing. We save the span in next_active_span and
+ * restore it once tracing of the previous statement is finished.
+ */
 static Span next_active_span;
 
 /*

--- a/src/pg_tracing_active_spans.c
+++ b/src/pg_tracing_active_spans.c
@@ -210,13 +210,9 @@ begin_active_span(pgTracingTraceContext * trace_context, Span * span,
 void
 end_latest_active_span(const TimestampTz *end_time)
 {
-	Span	   *span;
+	Span	   *span = pop_active_span();
 
-	/* Check if the level was allocated */
-	if (nested_level > max_nested_level)
-		return;
-
-	span = pop_active_span();
+	Assert(span->nested_level == nested_level);
 	end_span(span, end_time);
 	store_span(span);
 }

--- a/src/pg_tracing_active_spans.c
+++ b/src/pg_tracing_active_spans.c
@@ -94,6 +94,34 @@ pop_active_span(void)
 }
 
 /*
+ * Convert a node CmdType to the matching SpanType
+ */
+static SpanType
+command_type_to_span_type(CmdType cmd_type)
+{
+	switch (cmd_type)
+	{
+		case CMD_SELECT:
+			return SPAN_TOP_SELECT;
+		case CMD_INSERT:
+			return SPAN_TOP_INSERT;
+		case CMD_UPDATE:
+			return SPAN_TOP_UPDATE;
+		case CMD_DELETE:
+			return SPAN_TOP_DELETE;
+		case CMD_MERGE:
+			return SPAN_TOP_MERGE;
+		case CMD_UTILITY:
+			return SPAN_TOP_UTILITY;
+		case CMD_NOTHING:
+			return SPAN_TOP_NOTHING;
+		case CMD_UNKNOWN:
+			return SPAN_TOP_UNKNOWN;
+	}
+	return SPAN_TOP_UNKNOWN;
+}
+
+/*
  * Start a new top span if we've entered a new nested level or if the previous
  * span at the same level ended.
  */

--- a/src/pg_tracing_active_spans.c
+++ b/src/pg_tracing_active_spans.c
@@ -71,7 +71,7 @@ allocate_new_active_span(void)
 }
 
 /*
- * Get the latest top span
+ * Get the latest active span
  */
 Span *
 peek_active_span(void)
@@ -99,7 +99,7 @@ static Span * peek_active_span_for_current_level(void)
 }
 
 /*
- * Drop the latest top span for the current nested level
+ * Drop the latest active span for the current nested level
  */
 Span *
 pop_active_span(void)
@@ -140,7 +140,7 @@ command_type_to_span_type(CmdType cmd_type)
 }
 
 /*
- * Start a new top span if we've entered a new nested level or if the previous
+ * Start a new active span if we've entered a new nested level or if the previous
  * span at the same level ended.
  */
 static void
@@ -161,7 +161,7 @@ begin_active_span(pgTracingTraceContext * trace_context, Span * span,
 		per_level_buffers[nested_level].query_id = trace_context->query_id;
 
 	if (nested_level == 0)
-		/* Root top span, use the parent id from the trace context */
+		/* Root active span, use the parent id from the trace context */
 		parent_id = trace_context->traceparent.parent_id;
 	else
 	{
@@ -249,7 +249,7 @@ begin_active_span(pgTracingTraceContext * trace_context, Span * span,
 }
 
 /*
- * End the latest top span for the current nested level.
+ * End the latest active span for the current nested level.
  * If pop_span is true, store the span in the current_trace_spans and remove it
  * from the per level buffers.
  */
@@ -264,10 +264,10 @@ end_latest_active_span(const TimestampTz *end_time)
 }
 
 /*
- * Initialise buffers if we are in a new nested level and start associated top span.
- * If the top span already exists for the current nested level, this has no effect.
+ * Initialise buffers if we are in a new nested level and start associated active span.
+ * If the active span already exists for the current nested level, this has no effect.
  *
- * This needs to be called every time a top span could be started: post parse,
+ * This needs to be called every time an active span could be started: post parse,
  * planner, executor start and process utility
  *
  * In case of extended protocol using transaction block, the parse of the next

--- a/src/pg_tracing_parallel.c
+++ b/src/pg_tracing_parallel.c
@@ -69,7 +69,6 @@ add_parallel_context(const struct pgTracingTraceContext *trace_context,
 	{
 		ctx->trace_context = *trace_context;
 		/* We don't need to propagate root span index to parallel workers */
-		ctx->trace_context.root_span.span_id = 0;
 		ctx->trace_context.traceparent.parent_id = parent_id;
 	}
 }

--- a/src/pg_tracing_span.c
+++ b/src/pg_tracing_span.c
@@ -121,6 +121,15 @@ end_span(Span * span, const TimestampTz *end_time_input)
 }
 
 /*
+ * Reset span
+ */
+void
+reset_span(Span * span)
+{
+	span->span_id = 0;
+}
+
+/*
  * Get the type of a span.
  * If it is a node span, the name may be pulled from the stat file.
  */

--- a/src/pg_tracing_span.c
+++ b/src/pg_tracing_span.c
@@ -15,34 +15,6 @@
 #include "pg_tracing.h"
 
 /*
- * Convert a node CmdType to the matching SpanType
- */
-SpanType
-command_type_to_span_type(CmdType cmd_type)
-{
-	switch (cmd_type)
-	{
-		case CMD_SELECT:
-			return SPAN_TOP_SELECT;
-		case CMD_INSERT:
-			return SPAN_TOP_INSERT;
-		case CMD_UPDATE:
-			return SPAN_TOP_UPDATE;
-		case CMD_DELETE:
-			return SPAN_TOP_DELETE;
-		case CMD_MERGE:
-			return SPAN_TOP_MERGE;
-		case CMD_UTILITY:
-			return SPAN_TOP_UTILITY;
-		case CMD_NOTHING:
-			return SPAN_TOP_NOTHING;
-		case CMD_UNKNOWN:
-			return SPAN_TOP_UNKNOWN;
-	}
-	return SPAN_TOP_UNKNOWN;
-}
-
-/*
  * Initialize span fields
  */
 static void


### PR DESCRIPTION
Root span in the trace_context was used to deal with the extended protocol + transaction block issue: The parse of the next statement happens while the previous statement is ongoing since the portal is only dropped during the bind command.
We can replace it by a specific next_active_span to store span's information when we hit this case and restore it when needed.
We also remove max_nested_level: we can track whether pg_tracing memory context is allocated by checking pg_tracing_mem_ctx->isReset, making max_nested_level redundant.