### PR TITLE
Rework conditions for end of trace

### DIFF
--- a/expected/extended.out
+++ b/expected/extended.out
@@ -27,9 +27,10 @@ SELECT span_type, span_operation, parameters, lvl FROM peek_ordered_spans;
 ----------------+----------------+------------+-----
  Utility query  | BEGIN;         |            |   1
  ProcessUtility | ProcessUtility |            |   2
+ Select query   | select $1      |            |   1
  Utility query  | ROLLBACK;      |            |   1
  ProcessUtility | ProcessUtility |            |   2
-(4 rows)
+(5 rows)
 
 CALL clean_spans();
 -- Execute queries with extended protocol within an explicit transaction

--- a/expected/full_buffer.out
+++ b/expected/full_buffer.out
@@ -1,3 +1,4 @@
+SET pg_tracing.sample_rate = 0.0;
 -- A simple procedure creating nested calls
 CREATE OR REPLACE PROCEDURE loop_select(iterations int) AS
 $BODY$
@@ -8,7 +9,8 @@ BEGIN
 END;
 $BODY$
 LANGUAGE plpgsql;
--- Clear stats
+-- Clear stats and spans
+CALL clean_spans();
 select * from pg_tracing_reset();
  pg_tracing_reset 
 ------------------

--- a/expected/nested.out
+++ b/expected/nested.out
@@ -260,5 +260,12 @@ select span_operation, lvl FROM peek_ordered_spans where trace_id='0000000000000
  Commit                                          |   1
 (10 rows)
 
+-- Make sure we have 2 query_id associated with the trace
+SELECT count(distinct query_id)=2 from pg_tracing_consume_spans where trace_id='00000000000000000000000000000058';
+ ?column? 
+----------
+ t
+(1 row)
+
 -- Cleanup
 CALL clean_spans();

--- a/expected/planstate.out
+++ b/expected/planstate.out
@@ -1,48 +1,38 @@
 -- Test with planstate_spans disabled
 SET pg_tracing.planstate_spans = false;
-/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000001-0000000000000001-01'*/ SELECT s.relation_size + s.index_size
+/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000001-0000000000000001-01'*/ SELECT s.relation_size + s.index_size as sum_size
 FROM (SELECT
       pg_relation_size(C.oid) as relation_size,
       pg_indexes_size(C.oid) as index_size
-    FROM pg_class C) as s limit 1;
- ?column? 
-----------
-   851968
-(1 row)
-
+    FROM pg_class C) as s limit 1 \gset
 SELECT span_type, span_operation, deparse_info FROM peek_ordered_spans where trace_id='00000000000000000000000000000001';
-  span_type   |                                                       span_operation                                                        | deparse_info 
---------------+-----------------------------------------------------------------------------------------------------------------------------+--------------
- Select query | SELECT s.relation_size + s.index_size                                                                                      +| 
-              | FROM (SELECT pg_relation_size(C.oid) as relation_size, pg_indexes_size(C.oid) as index_size FROM pg_class C) as s limit $1; | 
- Planner      | Planner                                                                                                                     | 
- Executor     | ExecutorRun                                                                                                                 | 
- Commit       | Commit                                                                                                                      | 
+  span_type   |                                                       span_operation                                                       | deparse_info 
+--------------+----------------------------------------------------------------------------------------------------------------------------+--------------
+ Select query | SELECT s.relation_size + s.index_size as sum_size                                                                         +| 
+              | FROM (SELECT pg_relation_size(C.oid) as relation_size, pg_indexes_size(C.oid) as index_size FROM pg_class C) as s limit $1 | 
+ Planner      | Planner                                                                                                                    | 
+ Executor     | ExecutorRun                                                                                                                | 
+ Commit       | Commit                                                                                                                     | 
 (4 rows)
 
 -- Test with planstate_spans enabled
 SET pg_tracing.planstate_spans = true;
-/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000002-0000000000000002-01'*/  SELECT s.relation_size + s.index_size
+/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000002-0000000000000002-01'*/  SELECT s.relation_size + s.index_size as sum_size
 FROM (SELECT
       pg_relation_size(C.oid) as relation_size,
       pg_indexes_size(C.oid) as index_size
-    FROM pg_class C) as s limit 1;
- ?column? 
-----------
-   851968
-(1 row)
-
+    FROM pg_class C) as s limit 1 \gset
 SELECT span_type, span_operation, deparse_info FROM peek_ordered_spans where trace_id='00000000000000000000000000000002';
-  span_type   |                                                       span_operation                                                        | deparse_info 
---------------+-----------------------------------------------------------------------------------------------------------------------------+--------------
- Select query | SELECT s.relation_size + s.index_size                                                                                      +| 
-              | FROM (SELECT pg_relation_size(C.oid) as relation_size, pg_indexes_size(C.oid) as index_size FROM pg_class C) as s limit $1; | 
- Planner      | Planner                                                                                                                     | 
- Executor     | ExecutorRun                                                                                                                 | 
- Limit        | Limit                                                                                                                       | 
- SubqueryScan | SubqueryScan on s                                                                                                           | 
- SeqScan      | SeqScan on pg_class c                                                                                                       | 
- Commit       | Commit                                                                                                                      | 
+  span_type   |                                                       span_operation                                                       | deparse_info 
+--------------+----------------------------------------------------------------------------------------------------------------------------+--------------
+ Select query | SELECT s.relation_size + s.index_size as sum_size                                                                         +| 
+              | FROM (SELECT pg_relation_size(C.oid) as relation_size, pg_indexes_size(C.oid) as index_size FROM pg_class C) as s limit $1 | 
+ Planner      | Planner                                                                                                                    | 
+ Executor     | ExecutorRun                                                                                                                | 
+ Limit        | Limit                                                                                                                      | 
+ SubqueryScan | SubqueryScan on s                                                                                                          | 
+ SeqScan      | SeqScan on pg_class c                                                                                                      | 
+ Commit       | Commit                                                                                                                     | 
 (7 rows)
 
 -- Check generated spans when deparse is disabled

--- a/expected/select.out
+++ b/expected/select.out
@@ -85,28 +85,23 @@ SELECT processed_traces = :processed_traces + 1 from pg_tracing_info;
 (1 row)
 
 -- Trace a more complex query with multiple function calls
-/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000004-0000000000000004-01'*/ SELECT s.relation_size + s.index_size
+/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000004-0000000000000004-01'*/ SELECT s.relation_size + s.index_size as relation_size
 FROM (SELECT
       pg_relation_size(C.oid) as relation_size,
       pg_indexes_size(C.oid) as index_size
-    FROM pg_class C) as s limit 1;
- ?column? 
-----------
-   851968
-(1 row)
-
+    FROM pg_class C) as s limit 1 \gset
 -- Check the nested level of spans for a query with multiple function calls
 SELECT span_type, span_operation, lvl FROM peek_ordered_spans where trace_id='00000000000000000000000000000004';
-  span_type   |                                                       span_operation                                                        | lvl 
---------------+-----------------------------------------------------------------------------------------------------------------------------+-----
- Select query | SELECT s.relation_size + s.index_size                                                                                      +|   1
-              | FROM (SELECT pg_relation_size(C.oid) as relation_size, pg_indexes_size(C.oid) as index_size FROM pg_class C) as s limit $1; | 
- Planner      | Planner                                                                                                                     |   2
- Executor     | ExecutorRun                                                                                                                 |   2
- Limit        | Limit                                                                                                                       |   3
- SubqueryScan | SubqueryScan on s                                                                                                           |   4
- SeqScan      | SeqScan on pg_class c                                                                                                       |   5
- Commit       | Commit                                                                                                                      |   1
+  span_type   |                                                       span_operation                                                       | lvl 
+--------------+----------------------------------------------------------------------------------------------------------------------------+-----
+ Select query | SELECT s.relation_size + s.index_size as relation_size                                                                    +|   1
+              | FROM (SELECT pg_relation_size(C.oid) as relation_size, pg_indexes_size(C.oid) as index_size FROM pg_class C) as s limit $1 | 
+ Planner      | Planner                                                                                                                    |   2
+ Executor     | ExecutorRun                                                                                                                |   2
+ Limit        | Limit                                                                                                                      |   3
+ SubqueryScan | SubqueryScan on s                                                                                                          |   4
+ SeqScan      | SeqScan on pg_class c                                                                                                      |   5
+ Commit       | Commit                                                                                                                     |   1
 (7 rows)
 
 -- Check that we're in a correct state after a timeout

--- a/expected/setup.out
+++ b/expected/setup.out
@@ -15,11 +15,20 @@ AS $$
     SET pg_tracing.filter_query_ids TO DEFAULT;
     SET pg_tracing.sample_rate TO DEFAULT;
     SET pg_tracing.caller_sample_rate TO DEFAULT;
+    SET pg_tracing.track_utility TO DEFAULT;
 $$;
+CREATE OR REPLACE PROCEDURE reset_pg_tracing_test_table() AS $$
+BEGIN
+    DROP TABLE IF EXISTS pg_tracing_test;
+    CREATE TABLE pg_tracing_test (a int, b char(20));
+    COMMIT;
+    CREATE INDEX pg_tracing_index ON pg_tracing_test (a);
+    INSERT INTO pg_tracing_test VALUES(generate_series(1, 10000), 'aaa');
+    ANALYZE pg_tracing_test;
+END;
+$$ LANGUAGE plpgsql;
 -- Create test tables with data
-CREATE TABLE pg_tracing_test (a int, b char(20));
-CREATE INDEX pg_tracing_index ON pg_tracing_test (a);
-INSERT INTO pg_tracing_test VALUES(generate_series(1, 10000), 'aaa');
-ANALYZE pg_tracing_test;
+CALL reset_pg_tracing_test_table();
+NOTICE:  table "pg_tracing_test" does not exist, skipping
 CREATE TABLE m AS SELECT i AS k, (i || ' v')::text v FROM generate_series(1, 16, 3) i;
 ALTER TABLE m ADD UNIQUE (k);

--- a/expected/subxact.out
+++ b/expected/subxact.out
@@ -49,3 +49,4 @@ select span_operation, parameters, subxact_count, lvl FROM peek_ordered_spans;
 
 -- Cleaning
 CALL clean_spans();
+CALL reset_settings();

--- a/expected/utility.out
+++ b/expected/utility.out
@@ -157,6 +157,38 @@ select span_operation, parameters, lvl from peek_ordered_spans where right(trace
 (4 rows)
 
 CALL clean_spans();
+-- Test prepare with table modification
+PREPARE test_insert (integer, text) AS INSERT INTO pg_tracing_test(a, b) VALUES ($1, $2);
+/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000001-0000000000000001-01'*/ EXECUTE test_insert(100, '2');
+-- Check spans of test_insert execution
+select trace_id, span_operation, parameters, lvl from peek_ordered_spans WHERE trace_id='00000000000000000000000000000001';
+             trace_id             |                                      span_operation                                       |      parameters      | lvl 
+----------------------------------+-------------------------------------------------------------------------------------------+----------------------+-----
+ 00000000000000000000000000000001 | EXECUTE test_insert(100, '2');                                                            |                      |   1
+ 00000000000000000000000000000001 | ProcessUtility                                                                            |                      |   2
+ 00000000000000000000000000000001 | PREPARE test_insert (integer, text) AS INSERT INTO pg_tracing_test(a, b) VALUES ($1, $2); | $1 = '100', $2 = '2' |   3
+ 00000000000000000000000000000001 | Planner                                                                                   |                      |   4
+ 00000000000000000000000000000001 | ExecutorRun                                                                               |                      |   4
+ 00000000000000000000000000000001 | Insert on pg_tracing_test                                                                 |                      |   5
+ 00000000000000000000000000000001 | Result                                                                                    |                      |   6
+ 00000000000000000000000000000001 | Commit                                                                                    |                      |   1
+(8 rows)
+
+-- We should have only two query_ids
+SELECT count(distinct query_id)=2 from pg_tracing_peek_spans where trace_id='00000000000000000000000000000001';
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT query_id from pg_tracing_peek_spans where trace_id='00000000000000000000000000000001' AND span_operation = 'ProcessUtility' \gset
+SELECT query_id = :query_id from pg_tracing_peek_spans where trace_id='00000000000000000000000000000001' AND span_operation = 'Commit';
+ ?column? 
+----------
+ t
+(1 row)
+
+CALL clean_spans();
 -- Test prepared statement with generic plan
 SET plan_cache_mode='force_generic_plan';
 EXECUTE test_prepared_one_param(200);
@@ -276,4 +308,5 @@ select trace_id, span_type, span_operation, sql_error_code, lvl from peek_ordere
 
 -- Cleanup
 CALL clean_spans();
-SET pg_tracing.track_utility TO DEFAULT;
+CALL reset_settings();
+CALL reset_pg_tracing_test_table();

--- a/sql/nested.sql
+++ b/sql/nested.sql
@@ -177,6 +177,8 @@ SELECT span_id AS span_e_id,
 		from pg_tracing_peek_spans where parent_id=:'span_d_id' and span_type='Insert query' \gset
 
 select span_operation, lvl FROM peek_ordered_spans where trace_id='00000000000000000000000000000058';
+-- Make sure we have 2 query_id associated with the trace
+SELECT count(distinct query_id)=2 from pg_tracing_consume_spans where trace_id='00000000000000000000000000000058';
 
 -- Cleanup
 CALL clean_spans();

--- a/sql/planstate.sql
+++ b/sql/planstate.sql
@@ -1,20 +1,20 @@
 
 -- Test with planstate_spans disabled
 SET pg_tracing.planstate_spans = false;
-/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000001-0000000000000001-01'*/ SELECT s.relation_size + s.index_size
+/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000001-0000000000000001-01'*/ SELECT s.relation_size + s.index_size as sum_size
 FROM (SELECT
       pg_relation_size(C.oid) as relation_size,
       pg_indexes_size(C.oid) as index_size
-    FROM pg_class C) as s limit 1;
+    FROM pg_class C) as s limit 1 \gset
 SELECT span_type, span_operation, deparse_info FROM peek_ordered_spans where trace_id='00000000000000000000000000000001';
 
 -- Test with planstate_spans enabled
 SET pg_tracing.planstate_spans = true;
-/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000002-0000000000000002-01'*/  SELECT s.relation_size + s.index_size
+/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000002-0000000000000002-01'*/  SELECT s.relation_size + s.index_size as sum_size
 FROM (SELECT
       pg_relation_size(C.oid) as relation_size,
       pg_indexes_size(C.oid) as index_size
-    FROM pg_class C) as s limit 1;
+    FROM pg_class C) as s limit 1 \gset
 SELECT span_type, span_operation, deparse_info FROM peek_ordered_spans where trace_id='00000000000000000000000000000002';
 
 -- Check generated spans when deparse is disabled

--- a/sql/select.sql
+++ b/sql/select.sql
@@ -32,11 +32,11 @@ SELECT span_type, span_operation, lvl FROM peek_ordered_spans where trace_id='00
 SELECT processed_traces = :processed_traces + 1 from pg_tracing_info;
 
 -- Trace a more complex query with multiple function calls
-/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000004-0000000000000004-01'*/ SELECT s.relation_size + s.index_size
+/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000004-0000000000000004-01'*/ SELECT s.relation_size + s.index_size as relation_size
 FROM (SELECT
       pg_relation_size(C.oid) as relation_size,
       pg_indexes_size(C.oid) as index_size
-    FROM pg_class C) as s limit 1;
+    FROM pg_class C) as s limit 1 \gset
 -- Check the nested level of spans for a query with multiple function calls
 SELECT span_type, span_operation, lvl FROM peek_ordered_spans where trace_id='00000000000000000000000000000004';
 

--- a/sql/setup.sql
+++ b/sql/setup.sql
@@ -17,13 +17,22 @@ AS $$
     SET pg_tracing.filter_query_ids TO DEFAULT;
     SET pg_tracing.sample_rate TO DEFAULT;
     SET pg_tracing.caller_sample_rate TO DEFAULT;
+    SET pg_tracing.track_utility TO DEFAULT;
 $$;
 
+CREATE OR REPLACE PROCEDURE reset_pg_tracing_test_table() AS $$
+BEGIN
+    DROP TABLE IF EXISTS pg_tracing_test;
+    CREATE TABLE pg_tracing_test (a int, b char(20));
+    COMMIT;
+    CREATE INDEX pg_tracing_index ON pg_tracing_test (a);
+    INSERT INTO pg_tracing_test VALUES(generate_series(1, 10000), 'aaa');
+    ANALYZE pg_tracing_test;
+END;
+$$ LANGUAGE plpgsql;
+
 -- Create test tables with data
-CREATE TABLE pg_tracing_test (a int, b char(20));
-CREATE INDEX pg_tracing_index ON pg_tracing_test (a);
-INSERT INTO pg_tracing_test VALUES(generate_series(1, 10000), 'aaa');
-ANALYZE pg_tracing_test;
+CALL reset_pg_tracing_test_table();
 
 CREATE TABLE m AS SELECT i AS k, (i || ' v')::text v FROM generate_series(1, 16, 3) i;
 ALTER TABLE m ADD UNIQUE (k);

--- a/sql/subxact.sql
+++ b/sql/subxact.sql
@@ -16,3 +16,4 @@ select span_operation, parameters, subxact_count, lvl FROM peek_ordered_spans;
 
 -- Cleaning
 CALL clean_spans();
+CALL reset_settings();

--- a/src/pg_tracing.c
+++ b/src/pg_tracing.c
@@ -49,16 +49,16 @@
 
 #include "postgres.h"
 
+#include "access/parallel.h"
+#include "executor/executor.h"
 #include "access/xact.h"
 #include "common/pg_prng.h"
-#include "funcapi.h"
-#include "nodes/extensible.h"
 #include "optimizer/planner.h"
 #include "parser/analyze.h"
 #include "pg_tracing.h"
 #include "storage/ipc.h"
+#include "storage/proc.h"
 #include "tcop/utility.h"
-#include "utils/builtins.h"
 #include "utils/varlena.h"
 #include "utils/ruleutils.h"
 
@@ -1787,12 +1787,12 @@ pg_tracing_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 	if (qc != NULL)
 		process_utility_span->node_counters.rows = qc->nprocessed;
 
-    if (nested_level == 0)
-        current_query_id = query_id;
+	if (nested_level == 0)
+		current_query_id = query_id;
 
-    /* End ProcessUtility span and store it */
-    end_latest_active_span(&span_end_time);
-    end_latest_active_span(&span_end_time);
+	/* End ProcessUtility span and store it */
+	end_latest_active_span(&span_end_time);
+	end_latest_active_span(&span_end_time);
 
 	/*
 	 * If we're in an aborted transaction, xact callback won't be called so we
@@ -1840,13 +1840,13 @@ pg_tracing_xact_callback(XactEvent event, void *arg)
 		case XACT_EVENT_PARALLEL_COMMIT:
 			end_nested_level();
 			end_tracing();
-            break;
+			break;
 		case XACT_EVENT_ABORT:
 			/* TODO: Create an abort span */
 			end_nested_level();
 			end_tracing();
 			reset_span(&commit_span);
-            break;
+			break;
 		default:
 			break;
 	}

--- a/src/pg_tracing.c
+++ b/src/pg_tracing.c
@@ -1787,9 +1787,12 @@ pg_tracing_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 	if (qc != NULL)
 		process_utility_span->node_counters.rows = qc->nprocessed;
 
-	/* End ProcessUtility span and store it */
-	end_latest_active_span(&span_end_time);
-	end_latest_active_span(&span_end_time);
+    if (nested_level == 0)
+        current_query_id = query_id;
+
+    /* End ProcessUtility span and store it */
+    end_latest_active_span(&span_end_time);
+    end_latest_active_span(&span_end_time);
 
 	/*
 	 * If we're in an aborted transaction, xact callback won't be called so we


### PR DESCRIPTION
We can't rely on parse or executor traceparent to be set when dealing with extended protocol. Switch to mostly rely on current_trace_spans to know whether trace needs to be pushed in the shared buffer.
Also fix query_id for commit span within process utility.