### PR TITLE
Only create commit span on modifying transaction

### DIFF
--- a/expected/cursor.out
+++ b/expected/cursor.out
@@ -153,8 +153,7 @@ SELECT span_type, span_operation, lvl from peek_ordered_spans where trace_id='00
  Select query   | DECLARE c CURSOR FOR SELECT * from pg_tracing_test; |   3
  Utility query  | COMMIT;                                             |   1
  ProcessUtility | ProcessUtility                                      |   2
- Commit         | Commit                                              |   1
-(20 rows)
+(19 rows)
 
 -- Clean created spans
 CALL clean_spans();

--- a/expected/extended.out
+++ b/expected/extended.out
@@ -14,8 +14,7 @@ SELECT span_type, span_operation, parameters, lvl FROM peek_ordered_spans;
  Planner      | Planner        |                    |   2
  Executor     | ExecutorRun    |                    |   2
  Result       | Result         |                    |   3
- Commit       | Commit         |                    |   1
-(5 rows)
+(4 rows)
 
 CALL clean_spans();
 -- Trigger an error due to mismatching number of parameters
@@ -70,8 +69,7 @@ SELECT span_type, span_operation, parameters, lvl FROM peek_ordered_spans;
  Result         | Result         |                    |   3
  Utility query  | COMMIT;        |                    |   1
  ProcessUtility | ProcessUtility |                    |   2
- Commit         | Commit         |                    |   1
-(13 rows)
+(12 rows)
 
 CALL clean_spans();
 -- Mix extended protocol and simple protocol
@@ -121,8 +119,7 @@ SELECT span_type, span_operation, parameters, lvl FROM peek_ordered_spans;
  Result         | Result             |                        |   3
  Utility query  | COMMIT;            |                        |   1
  ProcessUtility | ProcessUtility     |                        |   2
- Commit         | Commit             |                        |   1
-(17 rows)
+(16 rows)
 
 CALL clean_spans();
 -- gdesc calls a single parse command then execute a query. Make sure we handle this case
@@ -136,14 +133,12 @@ SELECT span_type, span_operation, parameters, lvl FROM peek_ordered_spans;
   span_type   |                           span_operation                           |             parameters              | lvl 
 --------------+--------------------------------------------------------------------+-------------------------------------+-----
  Select query | SELECT $1                                                          | $1 = 1                              |   1
- Commit       | Commit                                                             |                                     |   1
  Select query | SELECT name AS "Column", pg_catalog.format_type(tp, tpm) AS "Type"+| $1 = '?column?', $2 = '23', $3 = -1 |   1
               | FROM (VALUES ($1, $2::pg_catalog.oid,$3)) s(name, tp, tpm)         |                                     | 
  Planner      | Planner                                                            |                                     |   2
  Executor     | ExecutorRun                                                        |                                     |   2
  Result       | Result                                                             |                                     |   3
- Commit       | Commit                                                             |                                     |   1
-(7 rows)
+(5 rows)
 
 CALL clean_spans();
 -- Trace only sampled statements
@@ -188,8 +183,7 @@ SELECT span_type, span_operation, parameters, lvl FROM peek_ordered_spans WHERE 
  Result         | Result            |                              |   3
  Utility query  | COMMIT;           |                              |   1
  ProcessUtility | ProcessUtility    |                              |   2
- Commit         | Commit            |                              |   1
-(17 rows)
+(16 rows)
 
 -- Test tracing only individual statements with extended protocol
 BEGIN;

--- a/expected/nested.out
+++ b/expected/nested.out
@@ -104,7 +104,7 @@ SET pg_tracing.track = 'top';
 SELECT count(*) from pg_tracing_consume_spans where trace_id='00000000000000000000000000000052';
  count 
 -------
-     6
+     5
 (1 row)
 
 -- Check tracking with no tracking
@@ -142,8 +142,7 @@ select span_operation, lvl FROM peek_ordered_spans where trace_id='0000000000000
  Planner             |   4
  ExecutorRun         |   4
  Result              |   5
- Commit              |   1
-(8 rows)
+(7 rows)
 
 -- Test again with utility tracking disabled
 SET pg_tracing.track_utility=off;
@@ -172,8 +171,7 @@ select span_operation, lvl FROM peek_ordered_spans where trace_id='0000000000000
  Planner                                 |   4
  ExecutorRun                             |   2
  Result                                  |   3
- Commit                                  |   1
-(7 rows)
+(6 rows)
 
 -- Create function with generate series
 CREATE OR REPLACE FUNCTION test_generate_series(IN anyarray, OUT x anyelement)
@@ -207,8 +205,7 @@ select span_operation, lvl FROM peek_ordered_spans where trace_id='0000000000000
  Result                                                                                 |   4
  select * from pg_catalog.generate_series(array_lower($1, $2), array_upper($1, $3), $4) |   4
  Planner                                                                                |   5
- Commit                                                                                 |   1
-(8 rows)
+(7 rows)
 
 -- +-----------------------------------------------------------+
 -- | A: Select test_function(1);                               |

--- a/expected/planstate.out
+++ b/expected/planstate.out
@@ -12,8 +12,7 @@ SELECT span_type, span_operation, deparse_info FROM peek_ordered_spans where tra
               | FROM (SELECT pg_relation_size(C.oid) as relation_size, pg_indexes_size(C.oid) as index_size FROM pg_class C) as s limit $1 | 
  Planner      | Planner                                                                                                                    | 
  Executor     | ExecutorRun                                                                                                                | 
- Commit       | Commit                                                                                                                     | 
-(4 rows)
+(3 rows)
 
 -- Test with planstate_spans enabled
 SET pg_tracing.planstate_spans = true;
@@ -32,8 +31,7 @@ SELECT span_type, span_operation, deparse_info FROM peek_ordered_spans where tra
  Limit        | Limit                                                                                                                      | 
  SubqueryScan | SubqueryScan on s                                                                                                          | 
  SeqScan      | SeqScan on pg_class c                                                                                                      | 
- Commit       | Commit                                                                                                                     | 
-(7 rows)
+(6 rows)
 
 -- Check generated spans when deparse is disabled
 SET pg_tracing.deparse_plan=false;
@@ -50,8 +48,7 @@ SELECT span_operation, deparse_info, parameters, lvl from peek_ordered_spans whe
  Planner                                             |              |            |   2
  ExecutorRun                                         |              |            |   2
  IndexScan using pg_tracing_index on pg_tracing_test |              |            |   3
- Commit                                              |              |            |   1
-(5 rows)
+(4 rows)
 
 -- Check generated spans when deparse is enabled
 SET pg_tracing.deparse_plan=true;
@@ -68,8 +65,7 @@ SELECT span_operation, deparse_info, parameters, lvl from peek_ordered_spans whe
  Planner                                             |                     |            |   2
  ExecutorRun                                         |                     |            |   2
  IndexScan using pg_tracing_index on pg_tracing_test | Index Cond: (a = 1) |            |   3
- Commit                                              |                     |            |   1
-(5 rows)
+(4 rows)
 
 -- Clean created spans
 CALL clean_spans();

--- a/expected/planstate_bitmap.out
+++ b/expected/planstate_bitmap.out
@@ -17,8 +17,7 @@ SELECT span_operation, deparse_info, parameters, lvl from peek_ordered_spans whe
  BitmapIndexScan on pg_tracing_index                       | Index Cond: (a = 1)                           |                        |   5
  BitmapIndexScan on pg_tracing_index                       | Index Cond: (a = 2)                           |                        |   5
  BitmapIndexScan on pg_tracing_index                       | Index Cond: (a = 3)                           |                        |   5
- Commit                                                    |                                               |                        |   1
-(9 rows)
+(8 rows)
 
 --
 -- +----------------------------------------------------------------------------------------------+

--- a/expected/planstate_hash.out
+++ b/expected/planstate_hash.out
@@ -15,8 +15,7 @@ SELECT span_operation, deparse_info, parameters, lvl from peek_ordered_spans whe
  SeqScan on pg_tracing_test r                                             |                    |            |   5
  Hash                                                                     |                    |            |   5
  SeqScan on pg_tracing_test s                                             |                    |            |   6
- Commit                                                                   |                    |            |   1
-(9 rows)
+(8 rows)
 
 -- +-----------------------------------------+
 -- | A: HashJoin                             |

--- a/expected/planstate_projectset.out
+++ b/expected/planstate_projectset.out
@@ -16,8 +16,7 @@ SELECT span_operation, deparse_info, parameters, lvl from peek_ordered_spans whe
  Result                                                                                                                                                                                                   |              |                                        |   4
  select $1[s], s operator(pg_catalog.-) pg_catalog.array_lower($1,$2) operator(pg_catalog.+) $3 from pg_catalog.generate_series(pg_catalog.array_lower($1,$4), pg_catalog.array_upper($1,$5), $6) as g(s) |              | $1 = 1, $2 = 1, $3 = 1, $4 = 1, $5 = 1 |   4
  Planner                                                                                                                                                                                                  |              |                                        |   5
- Commit                                                                                                                                                                                                   |              |                                        |   1
-(8 rows)
+(7 rows)
 
 -- +---------------------------------------------+
 -- | A: ProjectSet                               |

--- a/expected/planstate_union.out
+++ b/expected/planstate_union.out
@@ -22,8 +22,7 @@ SELECT span_operation, deparse_info, parameters, lvl from peek_ordered_spans whe
  SeqScan on pg_tracing_test                              | Filter : ((a + 0) < 10)    |                                     |   5
  Aggregate                                               |                            |                                     |   4
  SeqScan on pg_tracing_test pg_tracing_test_1            | Filter : ((a + 0) < 10000) |                                     |   5
- Commit                                                  |                            |                                     |   1
-(9 rows)
+(8 rows)
 
 -- +------------------------------------------+
 -- | A: Append                                |

--- a/expected/sample.out
+++ b/expected/sample.out
@@ -69,37 +69,29 @@ select span_operation, parameters, lvl from peek_ordered_spans;
  Planner        |            |   2
  ExecutorRun    |            |   2
  Result         |            |   3
- Commit         |            |   1
  SELECT $1;     | $1 = 2     |   1
  Planner        |            |   2
  ExecutorRun    |            |   2
  Result         |            |   3
- Commit         |            |   1
  SELECT $1;     | $1 = 3     |   1
  Planner        |            |   2
  ExecutorRun    |            |   2
  Result         |            |   3
- Commit         |            |   1
  SELECT $1;     | $1 = 4     |   1
  Planner        |            |   2
  ExecutorRun    |            |   2
  Result         |            |   3
- Commit         |            |   1
-(20 rows)
+(16 rows)
 
 -- Top spans should reuse generated ids and have trace_id = parent_id
 select span_operation, parameters from peek_ordered_spans where right(trace_id, 16) = parent_id;
  span_operation | parameters 
 ----------------+------------
  SELECT $1;     | $1 = 1
- Commit         | 
  SELECT $1;     | $1 = 2
- Commit         | 
  SELECT $1;     | $1 = 3
- Commit         | 
  SELECT $1;     | $1 = 4
- Commit         | 
-(8 rows)
+(4 rows)
 
 CALL clean_spans();
 -- Only trace query with sampled flag
@@ -155,18 +147,15 @@ select span_operation, parameters, lvl from peek_ordered_spans;
  Planner        |            |   2
  ExecutorRun    |            |   2
  Result         |            |   3
- Commit         |            |   1
  SELECT $1;     | $1 = 3     |   1
  Planner        |            |   2
  ExecutorRun    |            |   2
  Result         |            |   3
- Commit         |            |   1
  SELECT $1;     | $1 = 4     |   1
  Planner        |            |   2
  ExecutorRun    |            |   2
  Result         |            |   3
- Commit         |            |   1
-(15 rows)
+(12 rows)
 
 -- Cleaning
 CALL clean_spans();

--- a/expected/select.out
+++ b/expected/select.out
@@ -32,8 +32,7 @@ SELECT span_type, span_operation from pg_tracing_peek_spans where trace_id='0000
  Planner      | Planner
  Executor     | ExecutorRun
  Result       | Result
- Commit       | Commit
-(5 rows)
+(4 rows)
 
 -- Check userid
 SELECT userid = (SELECT usesysid FROM pg_user WHERE usename = current_user) FROM pg_tracing_peek_spans GROUP BY userid;
@@ -74,8 +73,7 @@ SELECT span_type, span_operation, lvl FROM peek_ordered_spans where trace_id='00
  Executor     | ExecutorRun                              |   2
  Aggregate    | Aggregate                                |   3
  FunctionScan | FunctionScan on current_database         |   4
- Commit       | Commit                                   |   1
-(6 rows)
+(5 rows)
 
 -- Check expected reported number of trace
 SELECT processed_traces = :processed_traces + 1 from pg_tracing_info;
@@ -101,8 +99,7 @@ SELECT span_type, span_operation, lvl FROM peek_ordered_spans where trace_id='00
  Limit        | Limit                                                                                                                      |   3
  SubqueryScan | SubqueryScan on s                                                                                                          |   4
  SeqScan      | SeqScan on pg_class c                                                                                                      |   5
- Commit       | Commit                                                                                                                     |   1
-(7 rows)
+(6 rows)
 
 -- Check that we're in a correct state after a timeout
 set statement_timeout=200;
@@ -135,8 +132,7 @@ SELECT span_type, span_operation, sql_error_code, lvl FROM peek_ordered_spans wh
  Planner      | Planner        | 00000          |   2
  Executor     | ExecutorRun    | 00000          |   2
  Result       | Result         | 00000          |   3
- Commit       | Commit         | 00000          |   1
-(5 rows)
+(4 rows)
 
 -- Cleanup
 SET plan_cache_mode='auto';
@@ -153,8 +149,7 @@ SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='0
  Planner             |                |   2
  ExecutorRun         |                |   2
  Limit               |                |   3
- Commit              |                |   1
-(5 rows)
+(4 rows)
 
 -- Test multiple statements in a single query
 /*dddbs='postgres.db',traceparent='00-0000000000000000000000000000000c-000000000000000c-01'*/ select 1; select 2;
@@ -175,8 +170,7 @@ SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='0
  Planner        |            |   2
  ExecutorRun    |            |   2
  Result         |            |   3
- Commit         |            |   1
-(5 rows)
+(4 rows)
 
 -- Check that parameters are not exported when disabled
 SET pg_tracing.export_parameters=false;
@@ -193,8 +187,7 @@ SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='0
  Planner            |            |   2
  ExecutorRun        |            |   2
  Result             |            |   3
- Commit             |            |   1
-(5 rows)
+(4 rows)
 
 SET pg_tracing.export_parameters=true;
 -- Check multi statement query
@@ -223,8 +216,7 @@ SELECT span_type, span_operation, parameters, lvl from peek_ordered_spans;
  Planner      | Planner        |                |   2
  Executor     | ExecutorRun    |                |   2
  Result       | Result         |                |   3
- Commit       | Commit         |                |   1
-(9 rows)
+(8 rows)
 
 CALL clean_spans();
 -- Check standalone trace
@@ -242,8 +234,7 @@ SELECT count(span_id) from pg_tracing_consume_spans group by span_id;
      1
      1
      1
-     1
-(5 rows)
+(4 rows)
 
 -- Trigger a planner error
 SELECT '\xDEADBEEF'::bytea::text::int;
@@ -284,8 +275,7 @@ SELECT span_type, span_operation, parameters, lvl from peek_ordered_spans;
  Result         | Result                                                                                                                                                                                                  |                                  |   4
  Select query   | select * from pg_catalog.generate_series(array_lower($1, $2), array_upper($1, $3), $4)                                                                                                                  | $1 = 1, $2 = 1, $3 = 1           |   4
  Planner        | Planner                                                                                                                                                                                                 |                                  |   5
- Commit         | Commit                                                                                                                                                                                                  |                                  |   1
-(11 rows)
+(10 rows)
 
 CALL clean_spans();
 -- Check function calls that don't have sources in pg_proc
@@ -310,8 +300,7 @@ SELECT span_type, span_operation, parameters, lvl from peek_ordered_spans;
  Planner      | Planner                                                                                |            |   4
  Executor     | ExecutorRun                                                                            |            |   4
  Result       | Result                                                                                 |            |   5
- Commit       | Commit                                                                                 |            |   1
-(13 rows)
+(12 rows)
 
 -- Cleanup
 CALL clean_spans();

--- a/expected/trigger_15.out
+++ b/expected/trigger_15.out
@@ -14,7 +14,6 @@ SELECT trace_id, span_type, span_operation, lvl from peek_ordered_spans where tr
  fed00000000000000000000000000001 | ProcessUtility | ProcessUtility                                       |   2
  fed00000000000000000000000000001 | Insert query   | explain INSERT INTO before_trigger_table VALUES($1); |   3
  fed00000000000000000000000000001 | Planner        | Planner                                              |   4
- fed00000000000000000000000000001 | Commit         | Commit                                               |   1
-(5 rows)
+(4 rows)
 
 CALL clean_spans();

--- a/expected/trigger_16.out
+++ b/expected/trigger_16.out
@@ -14,7 +14,6 @@ SELECT trace_id, span_type, span_operation, lvl from peek_ordered_spans where tr
  fed00000000000000000000000000001 | ProcessUtility | ProcessUtility                                       |   2
  fed00000000000000000000000000001 | Insert query   | explain INSERT INTO before_trigger_table VALUES($1); |   3
  fed00000000000000000000000000001 | Planner        | Planner                                              |   4
- fed00000000000000000000000000001 | Commit         | Commit                                               |   1
-(5 rows)
+(4 rows)
 
 CALL clean_spans();

--- a/expected/utility.out
+++ b/expected/utility.out
@@ -136,25 +136,21 @@ select span_operation, parameters, lvl from peek_ordered_spans;
  PREPARE test_prepared_one_param_2 (integer) AS SELECT $1; |            |   1
  ProcessUtility                                            |            |   2
  PREPARE test_prepared_one_param_2 (integer) AS SELECT $1; |            |   3
- Commit                                                    |            |   1
  EXECUTE test_prepared_one_param_2(100);                   |            |   1
  ProcessUtility                                            |            |   2
  PREPARE test_prepared_one_param_2 (integer) AS SELECT $1; | $1 = '100' |   3
  Planner                                                   |            |   4
  ExecutorRun                                               |            |   4
  Result                                                    |            |   5
- Commit                                                    |            |   1
-(11 rows)
+(9 rows)
 
 -- Check the top span (standalone top span has trace_id=parent_id)
 select span_operation, parameters, lvl from peek_ordered_spans where right(trace_id, 16) = parent_id;
                       span_operation                       | parameters | lvl 
 -----------------------------------------------------------+------------+-----
  PREPARE test_prepared_one_param_2 (integer) AS SELECT $1; |            |   1
- Commit                                                    |            |   1
  EXECUTE test_prepared_one_param_2(100);                   |            |   1
- Commit                                                    |            |   1
-(4 rows)
+(2 rows)
 
 CALL clean_spans();
 -- Test prepare with table modification
@@ -211,29 +207,23 @@ select span_operation, parameters, lvl from peek_ordered_spans;
 ---------------------------------------------------------+------------+-----
  SET plan_cache_mode='force_generic_plan';               |            |   1
  ProcessUtility                                          |            |   2
- Commit                                                  |            |   1
  EXECUTE test_prepared_one_param(200);                   |            |   1
  ProcessUtility                                          |            |   2
  PREPARE test_prepared_one_param (integer) AS SELECT $1; |            |   3
  ExecutorRun                                             |            |   4
  Result                                                  |            |   5
- Commit                                                  |            |   1
  SET plan_cache_mode TO DEFAULT;                         |            |   1
  ProcessUtility                                          |            |   2
- Commit                                                  |            |   1
-(12 rows)
+(9 rows)
 
 -- Check the top span (standalone top span has trace_id=parent_id)
 select span_operation, parameters, lvl from peek_ordered_spans where right(trace_id, 16) = parent_id;
               span_operation               | parameters | lvl 
 -------------------------------------------+------------+-----
  SET plan_cache_mode='force_generic_plan'; |            |   1
- Commit                                    |            |   1
  EXECUTE test_prepared_one_param(200);     |            |   1
- Commit                                    |            |   1
  SET plan_cache_mode TO DEFAULT;           |            |   1
- Commit                                    |            |   1
-(6 rows)
+(3 rows)
 
 CALL clean_spans();
 -- Second create extension should generate an error that is captured by span
@@ -294,8 +284,7 @@ select trace_id, span_type, span_operation, sql_error_code, lvl from peek_ordere
 ----------------------------------+----------------+----------------------------+----------------+-----
  00000000000000000000000000000005 | Utility query  | ANALYZE test_create_table; | 00000          |   1
  00000000000000000000000000000005 | ProcessUtility | ProcessUtility             | 00000          |   2
- 00000000000000000000000000000005 | Commit         | Commit                     | 00000          |   1
-(3 rows)
+(2 rows)
 
 /*dddbs='postgres.db',traceparent='00-00000000000000000000000000000006-0000000000000006-01'*/ DROP TABLE test_create_table;
 select trace_id, span_type, span_operation, sql_error_code, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000006';
@@ -304,6 +293,16 @@ select trace_id, span_type, span_operation, sql_error_code, lvl from peek_ordere
  00000000000000000000000000000006 | Utility query  | DROP TABLE test_create_table; | 00000          |   1
  00000000000000000000000000000006 | ProcessUtility | ProcessUtility                | 00000          |   2
  00000000000000000000000000000006 | Commit         | Commit                        | 00000          |   1
+(3 rows)
+
+-- Check VACUUM ANALYZE call
+/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000007-0000000000000007-01'*/ VACUUM ANALYZE pg_tracing_test;
+select trace_id, span_type, span_operation, sql_error_code, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000007';
+             trace_id             |   span_type    |         span_operation          | sql_error_code | lvl 
+----------------------------------+----------------+---------------------------------+----------------+-----
+ 00000000000000000000000000000007 | Utility query  | VACUUM ANALYZE pg_tracing_test; | 00000          |   1
+ 00000000000000000000000000000007 | ProcessUtility | ProcessUtility                  | 00000          |   2
+ 00000000000000000000000000000007 | Commit         | Commit                          | 00000          |   1
 (3 rows)
 
 -- Cleanup

--- a/sql/utility.sql
+++ b/sql/utility.sql
@@ -172,6 +172,10 @@ select trace_id, span_type, span_operation, sql_error_code, lvl from peek_ordere
 /*dddbs='postgres.db',traceparent='00-00000000000000000000000000000006-0000000000000006-01'*/ DROP TABLE test_create_table;
 select trace_id, span_type, span_operation, sql_error_code, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000006';
 
+-- Check VACUUM ANALYZE call
+/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000007-0000000000000007-01'*/ VACUUM ANALYZE pg_tracing_test;
+select trace_id, span_type, span_operation, sql_error_code, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000007';
+
 -- Cleanup
 CALL clean_spans();
 CALL reset_settings();

--- a/src/pg_tracing.c
+++ b/src/pg_tracing.c
@@ -152,7 +152,13 @@ static const struct config_enum_entry buffer_mode_options[] =
  * Global variables
  */
 
-/* Memory context for pg_tracing. */
+/*
+ * Memory context for pg_tracing.
+ *
+ * We can't rely on memory context like TopTransactionContext since
+ * some queries like vacuum analyze will end and start their own
+ * transactions while we still have active span
+ */
 MemoryContext pg_tracing_mem_ctx;
 
 /* trace context at the root level of parse/planning hook */

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -298,7 +298,7 @@ Span	   *allocate_new_active_span(void);
 
 Span	   *pop_active_span(void);
 Span	   *peek_active_span(void);
-uint64		push_active_span(const pgTracingTraceparent * traceparent, CmdType commandType,
+Span	   *push_active_span(const pgTracingTraceparent * traceparent, CmdType commandType,
 							 const Query *query, JumbleState *jstate, const PlannedStmt *pstmt,
 							 const char *query_text, TimestampTz start_time,
 							 HookPhase hook_phase, bool export_parameters);

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -298,7 +298,7 @@ Span	   *allocate_new_active_span(void);
 
 Span	   *pop_active_span(void);
 Span	   *peek_active_span(void);
-Span	   *push_active_span(const pgTracingTraceparent * traceparent, CmdType commandType,
+Span	   *push_active_span(const pgTracingTraceparent * traceparent, SpanType span_type,
 							 const Query *query, JumbleState *jstate, const PlannedStmt *pstmt,
 							 const char *query_text, TimestampTz start_time,
 							 HookPhase hook_phase, bool export_parameters);

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -298,10 +298,10 @@ Span	   *allocate_new_active_span(void);
 
 Span	   *pop_active_span(void);
 Span	   *peek_active_span(void);
-uint64		initialize_active_span(const pgTracingTraceparent * traceparent, CmdType commandType,
-								   const Query *query, JumbleState *jstate, const PlannedStmt *pstmt,
-								   const char *query_text, TimestampTz start_time,
-								   HookPhase hook_phase, bool export_parameters);
+uint64		push_active_span(const pgTracingTraceparent * traceparent, CmdType commandType,
+							 const Query *query, JumbleState *jstate, const PlannedStmt *pstmt,
+							 const char *query_text, TimestampTz start_time,
+							 HookPhase hook_phase, bool export_parameters);
 void
 			end_latest_active_span(const TimestampTz *end_time);
 void		cleanup_active_spans(void);

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -302,6 +302,10 @@ Span	   *push_active_span(const pgTracingTraceparent * traceparent, SpanType spa
 							 const Query *query, JumbleState *jstate, const PlannedStmt *pstmt,
 							 const char *query_text, TimestampTz start_time,
 							 HookPhase hook_phase, bool export_parameters);
+Span	   *push_child_active_span(const pgTracingTraceparent * traceparent, SpanType span_type,
+								   const Query *query, const PlannedStmt *pstmt,
+								   TimestampTz start_time);
+
 void
 			end_latest_active_span(const TimestampTz *end_time);
 void		cleanup_active_spans(void);

--- a/src/pg_tracing_active_spans.c
+++ b/src/pg_tracing_active_spans.c
@@ -58,8 +58,7 @@ allocate_new_active_span(void)
 		MemoryContextSwitchTo(oldcxt);
 		active_spans->max = 10;
 	}
-
-	if (active_spans->end >= active_spans->max)
+	else if (active_spans->end >= active_spans->max)
 	{
 		MemoryContext oldcxt;
 		int			old_spans_max = active_spans->max;

--- a/src/pg_tracing_active_spans.c
+++ b/src/pg_tracing_active_spans.c
@@ -282,10 +282,10 @@ end_latest_active_span(const TimestampTz *end_time)
  * we keep the active span for the next statement in next_active_span.
  */
 uint64
-initialize_active_span(const pgTracingTraceparent * traceparent, CmdType commandType,
-					   const Query *query, JumbleState *jstate, const PlannedStmt *pstmt,
-					   const char *query_text, TimestampTz start_time,
-					   HookPhase hook_phase, bool export_parameters)
+push_active_span(const pgTracingTraceparent * traceparent, CmdType commandType,
+				 const Query *query, JumbleState *jstate, const PlannedStmt *pstmt,
+				 const char *query_text, TimestampTz start_time,
+				 HookPhase hook_phase, bool export_parameters)
 {
 	Span	   *span = peek_active_span_for_current_level();
 	Span	   *parent_span = peek_active_span();

--- a/src/pg_tracing_active_spans.c
+++ b/src/pg_tracing_active_spans.c
@@ -281,7 +281,7 @@ end_latest_active_span(const TimestampTz *end_time)
  * statement happens while the previous span is still ongoing. To avoid conflict,
  * we keep the active span for the next statement in next_active_span.
  */
-uint64
+Span *
 push_active_span(const pgTracingTraceparent * traceparent, CmdType commandType,
 				 const Query *query, JumbleState *jstate, const PlannedStmt *pstmt,
 				 const char *query_text, TimestampTz start_time,
@@ -304,13 +304,13 @@ push_active_span(const pgTracingTraceparent * traceparent, CmdType commandType,
 			/* next_active_span is valid, use it and reset it */
 			*span = next_active_span;
 			reset_span(&next_active_span);
-			return span->span_id;
+			return span;
 		}
 	}
 	else
 	{
 		if (hook_phase != HOOK_PARSE || nested_level > 0)
-			return span->span_id;
+			return span;
 
 		/*
 		 * We're at level 0, in a parse hook while we still have an active
@@ -322,5 +322,5 @@ push_active_span(const pgTracingTraceparent * traceparent, CmdType commandType,
 
 	begin_active_span(traceparent, span, commandType, query, jstate, pstmt,
 					  query_text, start_time, export_parameters, parent_span);
-	return span->span_id;
+	return span;
 }

--- a/src/pg_tracing_active_spans.c
+++ b/src/pg_tracing_active_spans.c
@@ -241,6 +241,28 @@ end_latest_active_span(const TimestampTz *end_time)
 }
 
 /*
+ * Push a new span that will be the child of the latest active span
+ */
+Span *
+push_child_active_span(const pgTracingTraceparent * traceparent, SpanType span_type,
+					   const Query *query, const PlannedStmt *pstmt,
+					   TimestampTz start_time)
+{
+	Span	   *parent_span = peek_active_span();
+	Span	   *span = allocate_new_active_span();
+	uint64		query_id;
+
+	if (pstmt)
+		query_id = pstmt->queryId;
+	else
+		query_id = query->queryId;
+
+	begin_span(traceparent->trace_id, span, span_type, NULL,
+			   parent_span->span_id, query_id, &start_time);
+	return span;
+}
+
+/*
  * Initialise buffers if we are in a new nested level and start associated active span.
  * If the active span already exists for the current nested level, this has no effect.
  *


### PR DESCRIPTION
Commit on read only transaction is mostly a no-op and create more noise with possible 0ms duration spans. We're mostly interested in commit span that are possibly doing works like writing wal, fsync or waiting for a synchronous replicas.