### PR TITLE
Renaming and refactoring

### DIFF
--- a/src/pg_tracing.c
+++ b/src/pg_tracing.c
@@ -1336,7 +1336,6 @@ pg_tracing_planner_hook(Query *query, const char *query_string, int cursorOption
 		span_end_time = GetCurrentTimestamp();
 
 		nested_level--;
-		span_planner->sql_error_code = geterrcode();
 		handle_pg_error(traceparent, NULL, span_end_time);
 		PG_RE_THROW();
 	}

--- a/src/pg_tracing.c
+++ b/src/pg_tracing.c
@@ -1377,12 +1377,15 @@ pg_tracing_ExecutorStart(QueryDesc *queryDesc, int eflags)
 
 	if (nested_level == 0)
 	{
-		/* We're at the root level, copy trace context from parsing/planning */
+		/* We're at the root level, copy parse traceparent */
 		*traceparent = parse_traceparent;
 		reset_traceparent(&parse_traceparent);
 	}
 
-	/* Evaluate if query is sampled or not */
+	/*
+	 * A cached plan will start here without going through parse and plan so
+	 * we need to check trace_context here
+	 */
 	extract_trace_context(traceparent, NULL, queryDesc->plannedstmt->queryId);
 
 	/*

--- a/src/pg_tracing.c
+++ b/src/pg_tracing.c
@@ -1114,10 +1114,6 @@ handle_pg_error(const pgTracingTraceparent * traceparent,
 	int			sql_error_code;
 	Span	   *span;
 
-	/* If we're not sampling the query, bail out */
-	if (!pg_tracing_enabled(traceparent, nested_level))
-		return;
-
 	sql_error_code = geterrcode();
 
 	if (queryDesc != NULL)

--- a/src/pg_tracing.c
+++ b/src/pg_tracing.c
@@ -1029,6 +1029,13 @@ cleanup_tracing(void)
 		/* No need for cleaning */
 		return;
 	MemoryContextReset(pg_tracing_mem_ctx);
+
+	/*
+	 * Don't reset parse_traceparent here. With extended protocol +
+	 * transaction block, tracing of the previous statement may end while
+	 * parsing of the next statement was already done and stored in
+	 * parse_traceparent.
+	 */
 	reset_traceparent(&executor_traceparent);
 	within_declare_cursor = false;
 	current_trace_spans = NULL;
@@ -1087,7 +1094,7 @@ end_tracing(void)
 	pg_tracing_shared_state->stats.processed_traces++;
 	LWLockRelease(pg_tracing_shared_state->lock);
 
-	/* We can reset the memory context here */
+	/* We can cleanup the rest here */
 	cleanup_tracing();
 }
 

--- a/src/pg_tracing.c
+++ b/src/pg_tracing.c
@@ -1490,7 +1490,8 @@ pg_tracing_ExecutorRun(QueryDesc *queryDesc, ScanDirection direction, uint64 cou
 
 	/*
 	 * When fetching an existing cursor, the portal already exists and
-	 * ExecutorRun is the first hook called. Create the matching active span here.
+	 * ExecutorRun is the first hook called. Create the matching active span
+	 * here.
 	 */
 	push_active_span(traceparent, command_type_to_span_type(queryDesc->operation), NULL,
 					 NULL, queryDesc->plannedstmt, queryDesc->sourceText, span_start_time,

--- a/src/pg_tracing.c
+++ b/src/pg_tracing.c
@@ -642,9 +642,7 @@ end_nested_level(const TimestampTz *input_span_end_time)
 			InstrEndLoop(traced_planstate->planstate->instrument);
 			span_end_time = get_span_end_from_planstate(traced_planstate->planstate, traced_planstate->node_start, span_end_time);
 		}
-		end_span(span, &span_end_time);
-		store_span(span);
-		pop_active_span(NULL);
+		pop_active_span(&span_end_time);
 		span = peek_active_span();
 	}
 }
@@ -1122,16 +1120,14 @@ handle_pg_error(const pgTracingTraceparent * traceparent,
 
 	if (queryDesc != NULL)
 		process_query_desc(traceparent, queryDesc, sql_error_code, span_end_time);
-
-	span = pop_active_span(NULL);
+    span = peek_active_span();
 	while (span != NULL)
 	{
 		/* Assign the error code to the latest top span */
 		span->sql_error_code = sql_error_code;
-		end_span(span, &span_end_time);
-		store_span(span);
-		span = pop_active_span(NULL);
-	}
+		pop_active_span(&span_end_time);
+        span = peek_active_span();
+	};
 }
 
 /*

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -296,7 +296,7 @@ pgTracingStats get_empty_pg_tracing_stats(void);
 /* pg_tracing_active_spans.c */
 Span	   *allocate_new_active_span(void);
 
-Span	   *pop_active_span(void);
+Span	   *pop_active_span(const TimestampTz *end_time);
 Span	   *peek_active_span(void);
 Span	   *push_active_span(const pgTracingTraceparent * traceparent, SpanType span_type,
 							 const Query *query, JumbleState *jstate, const PlannedStmt *pstmt,
@@ -306,8 +306,6 @@ Span	   *push_child_active_span(const pgTracingTraceparent * traceparent, SpanTy
 								   const Query *query, const PlannedStmt *pstmt,
 								   TimestampTz start_time);
 
-void
-			end_latest_active_span(const TimestampTz *end_time);
 void		cleanup_active_spans(void);
 
 /* pg_tracing.c */


### PR DESCRIPTION
Move planstate manipulation functions to pg_tracing_planstate
Make hook functions more consistent: Check and bail out early if statement is not sampled
Replaced end_latest_active_span by pop_active_span