### PR TITLE
Fix qbuffer race condition

### DIFF
--- a/src/pg_tracing.c
+++ b/src/pg_tracing.c
@@ -684,14 +684,11 @@ store_span(const Span * span)
 
 	if (current_trace_spans->end >= current_trace_spans->max)
 	{
-		MemoryContext oldcxt;
-
 		/* Need to extend. */
 		current_trace_spans->max *= 2;
-		oldcxt = MemoryContextSwitchTo(pg_tracing_mem_ctx);
+		/* repalloc uses the pointer's memory context, no need to switch */
 		current_trace_spans = repalloc(current_trace_spans, sizeof(pgTracingSpans) +
 									   current_trace_spans->max * sizeof(Span));
-		MemoryContextSwitchTo(oldcxt);
 	}
 	current_trace_spans->spans[current_trace_spans->end++] = *span;
 }
@@ -1110,14 +1107,12 @@ initialize_trace_level(void)
 	else if (nested_level >= allocated_nested_level)
 	{
 		/* New nested level, allocate more memory */
-		MemoryContext oldcxt;
 		int			old_allocated_nested_level = allocated_nested_level;
 
-		oldcxt = MemoryContextSwitchTo(pg_tracing_mem_ctx);
 		allocated_nested_level++;
+		/* repalloc uses the pointer's memory context, no need to switch */
 		per_level_infos = repalloc0(per_level_infos, old_allocated_nested_level * sizeof(pgTracingPerLevelInfos),
 									allocated_nested_level * sizeof(pgTracingPerLevelInfos));
-		MemoryContextSwitchTo(oldcxt);
 	}
 }
 

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -270,7 +270,7 @@ extern void parse_trace_context(pgTracingTraceparent * traceparent, const char *
 extern const char *normalise_query(const char *query, int query_loc, int *query_len_p);
 extern bool text_store_file(pgTracingSharedState * pg_tracing, const char *query,
 							int query_len, Size *query_offset);
-extern const char *qtext_load_file(Size *buffer_size);
+extern char *qtext_load_file(Size *buffer_size);
 
 /* pg_tracing_span.c */
 extern void begin_span(TraceId trace_id, Span * span, SpanType type,

--- a/src/pg_tracing_query_process.c
+++ b/src/pg_tracing_query_process.c
@@ -439,7 +439,7 @@ error:
  *
  * On success, the buffer size is also returned into *buffer_size.
  */
-const char *
+char *
 qtext_load_file(Size *buffer_size)
 {
 	char	   *buf;

--- a/src/pg_tracing_sql_functions.c
+++ b/src/pg_tracing_sql_functions.c
@@ -251,6 +251,14 @@ pg_tracing_spans(PG_FUNCTION_ARGS)
 		return (Datum) 0;
 
 	LWLockAcquire(pg_tracing_shared_state->lock, lock_mode);
+	/* There was a new write, reload the text file */
+	if (pg_tracing_shared_state->extent != qbuffer_size)
+	{
+		free(qbuffer);
+		qbuffer = qtext_load_file(&qbuffer_size);
+	}
+	Assert(pg_tracing_shared_state->extent == qbuffer_size);
+
 	for (int i = 0; i < shared_spans->end; i++)
 	{
 		span = shared_spans->spans + i;

--- a/src/pg_tracing_sql_functions.c
+++ b/src/pg_tracing_sql_functions.c
@@ -213,7 +213,7 @@ pg_tracing_spans(PG_FUNCTION_ARGS)
 	bool		consume;
 	ReturnSetInfo *rsinfo = (ReturnSetInfo *) fcinfo->resultinfo;
 	Span	   *span;
-	const char *qbuffer;
+	char	   *qbuffer;
 	Size		qbuffer_size = 0;
 	LWLockMode	lock_mode = LW_SHARED;
 
@@ -263,6 +263,7 @@ pg_tracing_spans(PG_FUNCTION_ARGS)
 	pg_tracing_shared_state->stats.last_consume = GetCurrentTimestamp();
 	LWLockRelease(pg_tracing_shared_state->lock);
 
+	free(qbuffer);
 	return (Datum) 0;
 }
 


### PR DESCRIPTION
Fix possible race condition where writes could happen between reading and acquiring the lock.
Also add missing free of the malloced qbuffer.