### PR TITLE
Create background worker to send spans to an otel collector

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,7 @@ ARG PG_VERSION
 # Install packages
 RUN apt update
 RUN DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends \
-    build-essential ca-certificates curl gnupg git less flex bison \
-	libcurl4-gnutls-dev libicu-dev libncurses-dev libxml2-dev zlib1g-dev libedit-dev \
-    libkrb5-dev liblz4-dev libncurses6 libpam-dev libreadline-dev libselinux1-dev \
-    libssl-dev libxslt1-dev libzstd-dev uuid-dev make openssl sudo postgresql-common \
+    ca-certificates curl gnupg make sudo gcc \
 	&& rm -rf /var/lib/apt/lists/*
 
 RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
@@ -19,6 +16,7 @@ RUN echo "deb http://apt.postgresql.org/pub/repos/apt focal-pgdg main ${PG_VERSI
 # Install PostgreSQL
 RUN apt update \
     && DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends \
+     libcurl4-gnutls-dev libhttp-server-simple-perl libipc-run-perl \
      postgresql-server-dev-${PG_VERSION} \
      postgresql-${PG_VERSION} \
     && rm -rf /var/lib/apt/lists/*
@@ -45,6 +43,7 @@ COPY --chown=postgres pg_tracing.conf ./pg_tracing.conf
 
 # Tests
 COPY --chown=postgres ./sql/ ./sql
+COPY --chown=postgres ./t/ ./t
 COPY --chown=postgres ./expected/ ./expected
 
 RUN make -s clean

--- a/Makefile
+++ b/Makefile
@@ -78,4 +78,4 @@ run-test: build-test-pg$(PG_VERSION)
 	docker run					                \
 		--name $(TEST_CONTAINER_NAME) --rm		\
 		$(TEST_CONTAINER_NAME):pg$(PG_VERSION)	\
-		bash -c "PG_VERSION=$(PG_VERSION) make regresscheck_noinstall || (cat /usr/src/pg_tracing/regression.diffs && exit 1)"
+		bash -c "PG_VERSION=$(PG_VERSION) make regresscheck_noinstall || (cat /usr/src/pg_tracing/regression.diffs && exit 1); make installcheck"

--- a/Makefile
+++ b/Makefile
@@ -12,16 +12,17 @@ PG_CONFIG  = pg_config
 OBJS = \
 	$(WIN32RES) \
 	src/pg_tracing.o \
-	src/pg_tracing_query_process.o \
+	src/pg_tracing_active_spans.o \
+	src/pg_tracing_explain.o \
+	src/pg_tracing_json.o \
 	src/pg_tracing_parallel.o \
 	src/pg_tracing_planstate.o \
-	src/pg_tracing_explain.o \
+	src/pg_tracing_query_process.o \
 	src/pg_tracing_span.o \
 	src/pg_tracing_sql_functions.o \
-	src/pg_tracing_active_spans.o \
 	src/version_compat.o
 
-REGRESSCHECKS = setup utility select insert trigger cursor transaction
+REGRESSCHECKS = setup utility select insert trigger cursor json transaction
 ifeq ($(PG_VERSION),15)
 REGRESSCHECKS += trigger_15
 else

--- a/Makefile
+++ b/Makefile
@@ -9,12 +9,15 @@ EXTENSION  = pg_tracing
 DATA       = pg_tracing--0.1.0.sql
 PGFILEDESC = "pg_tracing - Distributed Tracing for PostgreSQL"
 PG_CONFIG  = pg_config
+# TODO: Make this optional
+SHLIB_LINK = -lcurl
 OBJS = \
 	$(WIN32RES) \
 	src/pg_tracing.o \
 	src/pg_tracing_active_spans.o \
 	src/pg_tracing_explain.o \
 	src/pg_tracing_json.o \
+	src/pg_tracing_otel.o \
 	src/pg_tracing_parallel.o \
 	src/pg_tracing_planstate.o \
 	src/pg_tracing_query_process.o \
@@ -36,6 +39,8 @@ REGRESSCHECKS += sample planstate planstate_bitmap planstate_hash \
 REGRESSCHECKS_OPTS = --no-locale --encoding=UTF8 --temp-config pg_tracing.conf
 
 PGXS := $(shell $(PG_CONFIG) --pgxs)
+
+TAP_TESTS = 1
 
 include $(PGXS)
 

--- a/doc/pg_tracing.md
+++ b/doc/pg_tracing.md
@@ -185,3 +185,15 @@ Controls the fraction of statements with SQLCommenter tracecontext and an enable
 ### pg_tracing.export_parameters (boolean)
 
 Controls whether the query's parameters should be exported in spans metadata. The default value is `on`.
+
+### pg_tracing.otel_endpoint (string)
+
+URL of the otel collector to send spans to. Example: 'http://127.0.0.1:4318/v1/traces'. This parameter can only be set at server start. The default value is NULL.
+
+### pg_tracing.otel_naptime (integer)
+
+Interval in milliseconds between upload of spans to the otel collector. This parameter can only be set at server start.
+
+### pg_tracing.otel_connect_timeout_ms (integer)
+
+Maximum time in milliseconds to connect to the otel collector. This includes DNS resolution and protocol handshake. This parameter can only be set at server start.

--- a/expected/cleanup.out
+++ b/expected/cleanup.out
@@ -4,4 +4,7 @@ DROP function test_function_project_set;
 DROP function test_function_result;
 DROP VIEW peek_ordered_spans;
 DROP VIEW peek_spans_with_level;
+DROP VIEW peek_ordered_json_spans;
+DROP VIEW peek_json_spans_with_level;
+DROP VIEW peek_json_spans;
 DROP EXTENSION pg_tracing;

--- a/expected/json.out
+++ b/expected/json.out
@@ -1,0 +1,33 @@
+-- Check generated json for simple select query
+/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000001-0000000000000001-01'*/ SELECT 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+-- Check generated json for multi line query
+/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000002-0000000000000002-01'*/ SELECT
+    1,
+2;
+ ?column? | ?column? 
+----------+----------
+        1 |        2
+(1 row)
+
+-- Check json results
+SELECT "traceId", name, kind, lvl FROM peek_ordered_json_spans;
+             traceId              |    name     | kind | lvl 
+----------------------------------+-------------+------+-----
+ 00000000000000000000000000000001 | SELECT $1;  |    2 |   1
+ 00000000000000000000000000000001 | Planner     |    2 |   2
+ 00000000000000000000000000000001 | ExecutorRun |    2 |   2
+ 00000000000000000000000000000001 | Result      |    2 |   3
+ 00000000000000000000000000000002 | SELECT $1, +|    2 |   1
+                                  | $2;         |      | 
+ 00000000000000000000000000000002 | Planner     |    2 |   2
+ 00000000000000000000000000000002 | ExecutorRun |    2 |   2
+ 00000000000000000000000000000002 | Result      |    2 |   3
+(8 rows)
+
+-- Cleanup
+CALL clean_spans();

--- a/expected/utility.out
+++ b/expected/utility.out
@@ -70,6 +70,22 @@ CREATE VIEW peek_spans_with_level AS
 -- Create utility view to keep order stable
 CREATE VIEW peek_ordered_spans AS
   SELECT * FROM peek_spans_with_level order by span_start, lvl, span_end, deparse_info;
+-- Column type to convert json to record
+create type span_json as ("traceId" text, "parentSpanId" text, "spanId" text, name text, "startTimeUnixNano" text, "endTimeUnixNano" text, kind int);
+CREATE VIEW peek_json_spans AS
+SELECT * FROM jsonb_populate_recordset(null::span_json, (SELECT jsonb_path_query(pg_tracing_json_spans()::jsonb, '$.resourceSpans[0].scopeSpans[0].spans')));
+-- View spans generated from json with their nested level
+CREATE VIEW peek_json_spans_with_level AS
+WITH RECURSIVE list_trace_spans("traceId", "parentSpanId", "spanId", name, "startTimeUnixNano", "endTimeUnixNano", kind, lvl) AS (
+        SELECT p.*, 1
+        FROM peek_json_spans p where not "parentSpanId"=ANY(SELECT span_id from pg_tracing_peek_spans)
+      UNION ALL
+        SELECT s.*, lvl + 1
+        FROM peek_json_spans s, list_trace_spans st
+        WHERE s."parentSpanId" = st."spanId"
+    ) SELECT * FROM list_trace_spans;
+CREATE VIEW peek_ordered_json_spans AS
+SELECT * FROM peek_json_spans_with_level order by "startTimeUnixNano", lvl, "endTimeUnixNano";
 -- Nothing should have been generated
 select count(*) = 0 from pg_tracing_consume_spans;
  ?column? 

--- a/pg_tracing--0.1.0.sql
+++ b/pg_tracing--0.1.0.sql
@@ -9,6 +9,8 @@ CREATE FUNCTION pg_tracing_info(
     OUT processed_spans bigint,
     OUT dropped_traces bigint,
     OUT dropped_spans bigint,
+    OUT otel_sent_spans bigint,
+    OUT otel_failures bigint,
     OUT last_consume timestamp with time zone,
     OUT stats_reset timestamp with time zone
 )

--- a/pg_tracing--0.1.0.sql
+++ b/pg_tracing--0.1.0.sql
@@ -21,6 +21,11 @@ RETURNS void
 AS 'MODULE_PATHNAME'
 LANGUAGE C;
 
+CREATE FUNCTION pg_tracing_json_spans()
+RETURNS text
+AS 'MODULE_PATHNAME'
+LANGUAGE C;
+
 CREATE FUNCTION pg_tracing_spans(
     IN consume bool,
     OUT trace_id char(32),

--- a/sql/cleanup.sql
+++ b/sql/cleanup.sql
@@ -4,4 +4,7 @@ DROP function test_function_project_set;
 DROP function test_function_result;
 DROP VIEW peek_ordered_spans;
 DROP VIEW peek_spans_with_level;
+DROP VIEW peek_ordered_json_spans;
+DROP VIEW peek_json_spans_with_level;
+DROP VIEW peek_json_spans;
 DROP EXTENSION pg_tracing;

--- a/sql/json.sql
+++ b/sql/json.sql
@@ -1,0 +1,13 @@
+-- Check generated json for simple select query
+/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000001-0000000000000001-01'*/ SELECT 1;
+
+-- Check generated json for multi line query
+/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000002-0000000000000002-01'*/ SELECT
+    1,
+2;
+
+-- Check json results
+SELECT "traceId", name, kind, lvl FROM peek_ordered_json_spans;
+
+-- Cleanup
+CALL clean_spans();

--- a/sql/utility.sql
+++ b/sql/utility.sql
@@ -80,6 +80,25 @@ CREATE VIEW peek_spans_with_level AS
 CREATE VIEW peek_ordered_spans AS
   SELECT * FROM peek_spans_with_level order by span_start, lvl, span_end, deparse_info;
 
+-- Column type to convert json to record
+create type span_json as ("traceId" text, "parentSpanId" text, "spanId" text, name text, "startTimeUnixNano" text, "endTimeUnixNano" text, kind int);
+CREATE VIEW peek_json_spans AS
+SELECT * FROM jsonb_populate_recordset(null::span_json, (SELECT jsonb_path_query(pg_tracing_json_spans()::jsonb, '$.resourceSpans[0].scopeSpans[0].spans')));
+
+-- View spans generated from json with their nested level
+CREATE VIEW peek_json_spans_with_level AS
+WITH RECURSIVE list_trace_spans("traceId", "parentSpanId", "spanId", name, "startTimeUnixNano", "endTimeUnixNano", kind, lvl) AS (
+        SELECT p.*, 1
+        FROM peek_json_spans p where not "parentSpanId"=ANY(SELECT span_id from pg_tracing_peek_spans)
+      UNION ALL
+        SELECT s.*, lvl + 1
+        FROM peek_json_spans s, list_trace_spans st
+        WHERE s."parentSpanId" = st."spanId"
+    ) SELECT * FROM list_trace_spans;
+
+CREATE VIEW peek_ordered_json_spans AS
+SELECT * FROM peek_json_spans_with_level order by "startTimeUnixNano", lvl, "endTimeUnixNano";
+
 -- Nothing should have been generated
 select count(*) = 0 from pg_tracing_consume_spans;
 

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -18,6 +18,7 @@
 
 /* Location of external text file */
 #define PG_TRACING_TEXT_FILE	PG_STAT_TMP_DIR "/pg_tracing.stat"
+#define INT64_HEX_FORMAT "%016" INT64_MODIFIER "x"
 
 /*
  * Counters extracted from query instrumentation

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -156,6 +156,9 @@ typedef struct pgTracingStats
 	int64		processed_spans;	/* number of spans processed */
 	int64		dropped_traces; /* number of traces aborted due to full buffer */
 	int64		dropped_spans;	/* number of dropped spans due to full buffer */
+	int64		otel_sent_spans;	/* number of spans sent to otel collector */
+	int64		otel_failures;	/* number of failures to send spans to otel
+								 * collector */
 	TimestampTz last_consume;	/* Last time the shared spans buffer was
 								 * consumed */
 	TimestampTz stats_reset;	/* Last time stats were reset */
@@ -333,5 +336,9 @@ extern void
 /* pg_tracing_json.c */
 extern void
 			marshal_spans_to_json(const pgTracingJsonContext * json_ctx, const pgTracingSpans * spans);
+
+/* pg_tracing_otel.c */
+extern void
+			pg_tracing_start_worker(const char *endpoint, int naptime, int connect_timeout_ms);
 
 #endif

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -233,6 +233,16 @@ typedef struct TracedPlanstate
 	int			nested_level;
 }			TracedPlanstate;
 
+/*
+ * Store context to marshal spans to json
+ */
+typedef struct pgTracingJsonContext
+{
+	StringInfo	str;
+	const char *qbuffer;
+	Size		qbuffer_size;
+}			pgTracingJsonContext;
+
 /* pg_tracing_explain.c */
 extern const char *plan_to_node_type(const Plan *plan);
 extern const char *plan_to_operation(const planstateTraceContext * planstateTraceContext, const PlanState *planstate, const char *spanName);
@@ -319,5 +329,9 @@ extern void
 			drop_all_spans_locked(void);
 extern void
 			pg_tracing_shmem_startup(void);
+
+/* pg_tracing_json.c */
+extern void
+			marshal_spans_to_json(const pgTracingJsonContext * json_ctx, const pgTracingSpans * spans);
 
 #endif

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -316,5 +316,7 @@ extern void
 			cleanup_tracing(void);
 extern void
 			drop_all_spans_locked(void);
+extern void
+			pg_tracing_shmem_startup(void);
 
 #endif

--- a/src/pg_tracing_json.c
+++ b/src/pg_tracing_json.c
@@ -1,0 +1,264 @@
+/*-------------------------------------------------------------------------
+ *
+ * pg_tracing_json.c
+ * 		pg_tracing json export functions.
+ *
+ * IDENTIFICATION
+ *	  src/pg_tracing_json.c
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "postgres.h"
+
+#include "pg_tracing.h"
+#include "utils/timestamp.h"
+#include "utils/json.h"
+
+/*
+ * From https://github.com/open-telemetry/opentelemetry-proto/blob/v1.3.1/opentelemetry/proto/trace/v1/trace.proto#L159-L161
+ */
+#define SPAN_KIND_SERVER 2
+
+static void
+append_text_field(StringInfo str, const char *label, const char *value, bool add_comma)
+{
+	escape_json(str, label);
+	appendStringInfoChar(str, ':');
+	escape_json(str, value);
+	if (add_comma)
+		appendStringInfoChar(str, ',');
+}
+
+static void
+append_int_field(StringInfo str, const char *label, int64 value, bool add_comma)
+{
+	appendStringInfo(str, "\"%s\": %" INT64_MODIFIER "d", label, value);
+	if (add_comma)
+		appendStringInfoChar(str, ',');
+}
+
+static void
+append_double_field(StringInfo str, const char *label, double value, bool add_comma)
+{
+	appendStringInfo(str, "\"%s\": %f", label, value);
+	if (add_comma)
+		appendStringInfoChar(str, ',');
+}
+
+static void
+append_nano_timestamp(StringInfo str, const char *label, TimestampTz value, bool add_comma)
+{
+	Timestamp	epoch = SetEpochTimestamp();
+	int64		result = value - epoch;
+
+	char	   *ts_nano = psprintf("%" INT64_MODIFIER "u000", result);
+
+	escape_json(str, label);
+	appendStringInfoChar(str, ':');
+	escape_json(str, ts_nano);
+	if (add_comma)
+		appendStringInfoChar(str, ',');
+}
+
+static void
+append_any_value_start(StringInfo str, const char *key)
+{
+	appendStringInfoChar(str, '{');
+	append_text_field(str, "key", key, false);
+	appendStringInfoChar(str, ',');
+	appendStringInfo(str, "\"value\":{");
+}
+
+static void
+append_attribute_string(StringInfo str, const char *key, const char *value, bool add_comma)
+{
+	append_any_value_start(str, key);
+	append_text_field(str, "stringValue", value, false);
+	appendStringInfo(str, "}}");
+	if (add_comma)
+		appendStringInfoChar(str, ',');
+}
+
+static void
+append_attribute_int(StringInfo str, const char *key, int64 value, bool skip_if_zero, bool add_comma)
+{
+	if (value == 0 && skip_if_zero)
+		return;
+	append_any_value_start(str, key);
+	append_int_field(str, "intValue", value, false);
+	appendStringInfo(str, "}}");
+	if (add_comma)
+		appendStringInfoChar(str, ',');
+}
+
+static void
+append_attribute_double(StringInfo str, const char *key, double value, bool skip_if_zero, bool add_comma)
+{
+	if (value == 0 && skip_if_zero)
+		return;
+	append_any_value_start(str, key);
+	append_double_field(str, "doubleValue", value, false);
+	appendStringInfo(str, "}}");
+	if (add_comma)
+		appendStringInfoChar(str, ',');
+}
+
+static void
+append_resource(StringInfo str)
+{
+	appendStringInfo(str, "\"resource\":");
+	appendStringInfo(str, "{\"attributes\": [");
+	/* TODO: Make the service name configurable */
+	append_attribute_string(str, "service.name", "PostgreSQL_Server", false);
+	appendStringInfo(str, "]}");
+}
+
+static void
+append_plan_counters(StringInfo str, const PlanCounters * plan_counters)
+{
+	append_attribute_double(str, "plan.cost.startup", plan_counters->startup_cost, true, true);
+	append_attribute_double(str, "plan.cost.total", plan_counters->total_cost, true, true);
+	append_attribute_double(str, "plan.rows", plan_counters->plan_rows, true, true);
+	append_attribute_int(str, "plan.width", plan_counters->plan_width, true, true);
+}
+
+static void
+append_node_counters(StringInfo str, const NodeCounters * node_counters)
+{
+	double		blk_read_time,
+				blk_write_time,
+				temp_blk_read_time,
+				temp_blk_write_time;
+	double		generation_counter,
+				inlining_counter,
+				optimization_counter,
+				emission_counter;
+	int64		jit_created_functions;
+
+	append_attribute_int(str, "node.rows", node_counters->rows, true, true);
+	append_attribute_int(str, "node.nloops", node_counters->nloops, true, true);
+
+	/* Block usage */
+	append_attribute_int(str, "blocks.shared.hit", node_counters->buffer_usage.shared_blks_hit, true, true);
+	append_attribute_int(str, "blocks.shared.read", node_counters->buffer_usage.shared_blks_read, true, true);
+	append_attribute_int(str, "blocks.shared.dirtied", node_counters->buffer_usage.shared_blks_dirtied, true, true);
+	append_attribute_int(str, "blocks.shared.written", node_counters->buffer_usage.shared_blks_written, true, true);
+
+	append_attribute_int(str, "blocks.local.hit", node_counters->buffer_usage.local_blks_hit, true, true);
+	append_attribute_int(str, "blocks.local.read", node_counters->buffer_usage.local_blks_read, true, true);
+	append_attribute_int(str, "blocks.local.dirtied", node_counters->buffer_usage.local_blks_dirtied, true, true);
+	append_attribute_int(str, "blocks.local.written", node_counters->buffer_usage.local_blks_written, true, true);
+
+#if PG_VERSION_NUM >= 170000
+	blk_read_time = INSTR_TIME_GET_MILLISEC(node_counters->buffer_usage.shared_blk_read_time);
+	blk_write_time = INSTR_TIME_GET_MILLISEC(node_counters->buffer_usage.shared_blk_write_time);
+#else
+	blk_read_time = INSTR_TIME_GET_MILLISEC(node_counters->buffer_usage.blk_read_time);
+	blk_write_time = INSTR_TIME_GET_MILLISEC(node_counters->buffer_usage.blk_write_time);
+#endif
+	append_attribute_double(str, "blocks.io.read_time", blk_read_time, true, true);
+	append_attribute_double(str, "blocks.io.write_time", blk_write_time, true, true);
+
+	temp_blk_read_time = INSTR_TIME_GET_MILLISEC(node_counters->buffer_usage.temp_blk_read_time);
+	temp_blk_write_time = INSTR_TIME_GET_MILLISEC(node_counters->buffer_usage.temp_blk_write_time);
+	append_attribute_double(str, "temp_blocks.io.read_time", temp_blk_read_time, true, true);
+	append_attribute_double(str, "temp_blocks.io.write_time", temp_blk_write_time, true, true);
+	append_attribute_int(str, "temp_blocks.read", node_counters->buffer_usage.temp_blks_read, true, true);
+	append_attribute_int(str, "temp_blocks.written", node_counters->buffer_usage.temp_blks_written, true, true);
+
+	/* WAL usage */
+	append_attribute_int(str, "wal.records", node_counters->wal_usage.wal_records, true, true);
+	append_attribute_int(str, "wal.fpi", node_counters->wal_usage.wal_fpi, true, true);
+	append_attribute_int(str, "wal.bytes", node_counters->wal_usage.wal_bytes, true, true);
+
+	/* JIT usage */
+	generation_counter = INSTR_TIME_GET_MILLISEC(node_counters->jit_usage.generation_counter);
+	inlining_counter = INSTR_TIME_GET_MILLISEC(node_counters->jit_usage.inlining_counter);
+	optimization_counter = INSTR_TIME_GET_MILLISEC(node_counters->jit_usage.optimization_counter);
+	emission_counter = INSTR_TIME_GET_MILLISEC(node_counters->jit_usage.emission_counter);
+	jit_created_functions = node_counters->jit_usage.created_functions;
+	append_attribute_int(str, "jit.created_functions", jit_created_functions, true, true);
+	append_attribute_double(str, "jit.generation_counter", generation_counter, true, true);
+	append_attribute_double(str, "jit.inlining_counter", inlining_counter, true, true);
+	append_attribute_double(str, "jit.optimization_counter", optimization_counter, true, true);
+	append_attribute_double(str, "jit.emission_counter", emission_counter, true, true);
+}
+
+static void
+append_span_attributes(StringInfo str, const Span * span)
+{
+	appendStringInfo(str, "\"attributes\": [");
+
+	if (span->type >= SPAN_NODE && span->type <= SPAN_TOP_UNKNOWN)
+		append_node_counters(str, &span->node_counters);
+	if (span->type >= SPAN_TOP_SELECT && span->type <= SPAN_TOP_UNKNOWN)
+		append_plan_counters(str, &span->plan_counters);
+
+	if (span->sql_error_code > 0)
+		append_attribute_string(str, "query.sql_error_code", unpack_sql_state(span->sql_error_code), true);
+	append_attribute_int(str, "query.query_id", span->query_id, false, true);
+	append_attribute_int(str, "query.subxact_count", span->subxact_count, true, true);
+
+	append_attribute_int(str, "backend.pid", span->be_pid, false, true);
+	append_attribute_int(str, "backend.user_id", span->user_id, false, true);
+	append_attribute_int(str, "backend.database_id", span->database_id, false, false);
+
+	appendStringInfoChar(str, ']');
+}
+
+static void
+append_span(const pgTracingJsonContext * json_ctx, const Span * span)
+{
+	char		trace_id[33];
+	char		parent_id[17];
+	char		span_id[17];
+	const char *operation_name;
+	StringInfo	str = json_ctx->str;
+
+	operation_name = get_operation_name(span, json_ctx->qbuffer, json_ctx->qbuffer_size);
+
+	pg_snprintf(trace_id, 33, INT64_HEX_FORMAT INT64_HEX_FORMAT,
+				span->trace_id.traceid_left,
+				span->trace_id.traceid_right);
+	pg_snprintf(parent_id, 17, INT64_HEX_FORMAT, span->parent_id);
+	pg_snprintf(span_id, 17, INT64_HEX_FORMAT, span->span_id);
+
+	appendStringInfoChar(str, '{');
+	append_text_field(str, "traceId", trace_id, true);
+	append_text_field(str, "spanId", span_id, true);
+	append_text_field(str, "parentSpanId", parent_id, true);
+	append_text_field(str, "name", operation_name, true);
+	append_int_field(str, "kind", SPAN_KIND_SERVER, true);
+	append_nano_timestamp(str, "startTimeUnixNano", span->start, true);
+	append_nano_timestamp(str, "endTimeUnixNano", span->end, true);
+	append_span_attributes(str, span);
+	appendStringInfoChar(str, '}');
+}
+
+static void
+append_scope_spans(const pgTracingJsonContext * json_ctx, const pgTracingSpans * spans)
+{
+	appendStringInfo(json_ctx->str, "\"scopeSpans\":[");
+	appendStringInfo(json_ctx->str, "{\"spans\": [");
+	for (int i = 0; i < shared_spans->end; i++)
+	{
+		append_span(json_ctx, spans->spans + i);
+		if (i + 1 < shared_spans->end)
+			appendStringInfoChar(json_ctx->str, ',');
+	}
+	appendStringInfo(json_ctx->str, "]}]");
+}
+
+/*
+ * Marshal spans json compatible for otel http endpoint
+ */
+void
+marshal_spans_to_json(const pgTracingJsonContext * json_ctx, const pgTracingSpans * spans)
+{
+	appendStringInfo(json_ctx->str, "{\"resourceSpans\": [{");
+	append_resource(json_ctx->str);
+	appendStringInfoChar(json_ctx->str, ',');
+	append_scope_spans(json_ctx, spans);
+
+	appendStringInfo(json_ctx->str, "}]}");
+}

--- a/src/pg_tracing_otel.c
+++ b/src/pg_tracing_otel.c
@@ -1,0 +1,322 @@
+/*-------------------------------------------------------------------------
+ *
+ * pg_tracing_otel.c
+ * 		pg_tracing otel export functions.
+ *
+ * IDENTIFICATION
+ *	  src/pg_tracing_otel.c
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "postgres.h"
+
+#include "pg_tracing.h"
+#include "postmaster/bgworker.h"
+#include "utils/timestamp.h"
+#include "postmaster/interrupt.h"
+#include "utils/memutils.h"
+#include "storage/latch.h"
+#include "storage/procsignal.h"
+#include <curl/curl.h>
+
+/* Background worker entry point */
+PGDLLEXPORT void pg_tracing_otel_exporter(Datum main_arg);
+
+typedef struct OtelContext
+{
+	CURL	   *curl;			/* Curl handle */
+	struct curl_slist *headers; /* list of http headers common to all requests */
+	const char *endpoint;		/* Target otel collector */
+	int			naptime;		/* Duration between upload ot spans to the
+								 * otel collector */
+	int			connect_timeout_ms; /* Connection timeout in ms */
+}			OtelContext;
+
+/* State and configuration of the otel exporter */
+static OtelContext otelContext;
+
+/* Dedicated memory contexts for otel exporter background worker. */
+static MemoryContext otel_exporter_mem_ctx;
+
+/* Memory context used for json marshalling */
+static MemoryContext marshal_mem_ctx;
+
+/* Memory context used for libcurl */
+static MemoryContext curl_mem_ctx;
+
+/* Curl memory callback functions */
+
+static void *
+pg_tracing_curl_malloc_callback(size_t size)
+{
+	if (size)
+		return MemoryContextAlloc(curl_mem_ctx, size);
+	return NULL;
+}
+
+static void
+pg_tracing_curl_free_callback(void *ptr)
+{
+	if (ptr)
+		pfree(ptr);
+}
+
+static void *
+pg_tracing_curl_realloc_callback(void *ptr, size_t size)
+{
+	if (ptr && size)
+		return repalloc(ptr, size);
+	if (size)
+		return MemoryContextAlloc(curl_mem_ctx, size);
+	return ptr;
+}
+
+static char *
+pg_tracing_curl_strdup_callback(const char *str)
+{
+	return MemoryContextStrdup(curl_mem_ctx, str);
+}
+
+static void *
+pg_tracing_curl_calloc_callback(size_t nmemb, size_t size)
+{
+	return MemoryContextAllocZero(curl_mem_ctx, nmemb * size);
+}
+
+/*
+ * Send json to configured otel http endpoint
+ */
+static CURLcode
+send_json_trace(OtelContext * octx, const char *json_span)
+{
+	CURLcode	res;
+
+	if (octx->curl == NULL)
+	{
+		/*
+		 * Keep a single handle and don't clean it to keep the connection
+		 * opened
+		 */
+		octx->curl = curl_easy_init();
+		if (octx->curl == NULL)
+		{
+			elog(ERROR, "Couldn't initialize curl handle");
+			return CURLE_FAILED_INIT;
+		}
+		curl_easy_setopt(octx->curl, CURLOPT_HTTPHEADER, octx->headers);
+		curl_easy_setopt(octx->curl, CURLOPT_URL, octx->endpoint);
+		curl_easy_setopt(octx->curl, CURLOPT_CONNECTTIMEOUT_MS, octx->connect_timeout_ms);
+	}
+	curl_easy_setopt(octx->curl, CURLOPT_POSTFIELDS, json_span);
+	curl_easy_setopt(octx->curl, CURLOPT_POSTFIELDSIZE, (long) strlen(json_span));
+
+	res = curl_easy_perform(octx->curl);
+	return res;
+}
+
+/*
+ * Consume and send spans to the otel collector
+ */
+static void
+send_spans_to_otel_collector(OtelContext * octx)
+{
+	int			num_spans = 0;
+	char	   *qbuffer;
+	Size		qbuffer_size = 0;
+	pgTracingJsonContext json_ctx;
+	StringInfoData str;
+
+	/*
+	 * Do a quick check with a shared lock to see if there are any spans to
+	 * send
+	 */
+	LWLockAcquire(pg_tracing_shared_state->lock, LW_SHARED);
+	if (shared_spans->end == 0)
+	{
+		LWLockRelease(pg_tracing_shared_state->lock);
+		return;
+	}
+	LWLockRelease(pg_tracing_shared_state->lock);
+
+	LWLockAcquire(pg_tracing_shared_state->lock, LW_EXCLUSIVE);
+	/* Recheck for spans to send */
+	if (shared_spans->end == 0)
+	{
+		LWLockRelease(pg_tracing_shared_state->lock);
+		return;
+	}
+	num_spans = shared_spans->end;
+
+	qbuffer = qtext_load_file(&qbuffer_size);
+	if (qbuffer == NULL)
+	{
+		LWLockRelease(pg_tracing_shared_state->lock);
+		return;
+	}
+
+	/* Build the json context */
+	initStringInfo(&str);
+	json_ctx.str = &str;
+	json_ctx.qbuffer = qbuffer;
+	json_ctx.qbuffer_size = qbuffer_size;
+
+	/* Do marshalling within marshal memory context */
+	MemoryContextSwitchTo(marshal_mem_ctx);
+	marshal_spans_to_json(&json_ctx, shared_spans);
+	MemoryContextSwitchTo(otel_exporter_mem_ctx);
+
+	/* TODO: Only drop if we manage to send spans */
+	drop_all_spans_locked();
+
+	pg_tracing_shared_state->stats.last_consume = GetCurrentTimestamp();
+	LWLockRelease(pg_tracing_shared_state->lock);
+
+	if (str.len > 0)
+	{
+		CURLcode	ret;
+
+		elog(INFO, "Sending %d spans to %s", num_spans, octx->endpoint);
+		ret = send_json_trace(octx, str.data);
+
+		/* TODO: Switch to atomic values for stats? */
+		LWLockAcquire(pg_tracing_shared_state->lock, LW_EXCLUSIVE);
+		if (ret == CURLE_OK)
+		{
+			pg_tracing_shared_state->stats.otel_sent_spans += num_spans;
+		}
+		else
+		{
+			ereport(WARNING, errmsg("curl_easy_perform() failed: %s\n",
+									curl_easy_strerror(ret)));
+			pg_tracing_shared_state->stats.otel_failures++;
+		}
+		LWLockRelease(pg_tracing_shared_state->lock);
+	}
+
+	/* Json was pushed, we can clear the memory used for marshalling */
+	MemoryContextReset(marshal_mem_ctx);
+	free(qbuffer);
+}
+
+/*
+ * Register otel exporter background worker
+ */
+void
+pg_tracing_start_worker(const char *endpoint, int naptime, int connect_timeout_ms)
+{
+	BackgroundWorker worker;
+	BackgroundWorkerHandle *handle;
+	BgwHandleStatus status;
+	pid_t		pid;
+
+	MemSet(&worker, 0, sizeof(BackgroundWorker));
+	worker.bgw_flags = BGWORKER_SHMEM_ACCESS;
+	worker.bgw_start_time = BgWorkerStart_ConsistentState;
+	strcpy(worker.bgw_library_name, "pg_tracing");
+	strcpy(worker.bgw_function_name, "pg_tracing_otel_exporter");
+	strcpy(worker.bgw_name, "pg_tracing otel exporter");
+	strcpy(worker.bgw_type, "pg_tracing otel exporter");
+
+	/* Initialize the otel context struct */
+	otelContext.headers = NULL;
+	otelContext.curl = NULL;
+	otelContext.endpoint = endpoint;
+	otelContext.naptime = naptime;
+	otelContext.connect_timeout_ms = connect_timeout_ms;
+
+	if (process_shared_preload_libraries_in_progress)
+	{
+		RegisterBackgroundWorker(&worker);
+		return;
+	}
+
+	if (!RegisterDynamicBackgroundWorker(&worker, &handle))
+		ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_RESOURCES),
+				 errmsg("could not register background process"),
+				 errhint("You may need to increase max_worker_processes.")));
+
+	status = WaitForBackgroundWorkerStartup(handle, &pid);
+	if (status != BGWH_STARTED)
+		ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_RESOURCES),
+				 errmsg("could not start background process"),
+				 errhint("More details may be available in the server log.")));
+}
+
+/*
+ * Entry point for otel exporter background worker
+ *
+ * Initialize all memory contexts and start the main loop that
+ * will send the spans to the configured otel collector
+ */
+void
+pg_tracing_otel_exporter(Datum main_arg)
+{
+	/* Establish signal handlers; once that's done, unblock signals. */
+	pqsignal(SIGTERM, SignalHandlerForShutdownRequest);
+	pqsignal(SIGHUP, SignalHandlerForConfigReload);
+	pqsignal(SIGUSR1, procsignal_sigusr1_handler);
+	BackgroundWorkerUnblockSignals();
+
+	/* Go through pg_tracing shmem startup to attach the shared_spans global */
+	pg_tracing_shmem_startup();
+
+	/* Initialize otel exporter memory context */
+	otel_exporter_mem_ctx = AllocSetContextCreate(TopMemoryContext,
+												  "pg_tracing otel exporter",
+												  ALLOCSET_DEFAULT_SIZES);
+	/* And switch to the created context */
+	MemoryContextSwitchTo(otel_exporter_mem_ctx);
+
+	/* Create marshalling and curl context as children contexts */
+	marshal_mem_ctx = AllocSetContextCreate(otel_exporter_mem_ctx,
+											"json marshalling",
+											ALLOCSET_DEFAULT_SIZES);
+	curl_mem_ctx = AllocSetContextCreate(otel_exporter_mem_ctx,
+										 "libcurl",
+										 ALLOCSET_DEFAULT_SIZES);
+
+	/* Initialize libcurl */
+	if (curl_global_init_mem(CURL_GLOBAL_ALL, pg_tracing_curl_malloc_callback,
+							 pg_tracing_curl_free_callback,
+							 pg_tracing_curl_realloc_callback,
+							 pg_tracing_curl_strdup_callback,
+							 pg_tracing_curl_calloc_callback))
+		ereport(ERROR, (
+						errcode(ERRCODE_OUT_OF_MEMORY),
+						errmsg("curl_global_init_mem")));
+
+
+	/*
+	 * Create the content type header only once since it will always be the
+	 * same
+	 */
+	otelContext.headers = curl_slist_append(otelContext.headers, "Content-Type: application/json");
+
+	while (!ShutdownRequestPending)
+	{
+		int			rc;
+
+		/* Clean the latch and wait for the next event */
+		ResetLatch(MyLatch);
+		rc = WaitLatch(MyLatch,
+					   WL_LATCH_SET | WL_TIMEOUT | WL_EXIT_ON_PM_DEATH,
+					   otelContext.naptime,
+					   PG_WAIT_EXTENSION);
+
+		/* Send spans if we have any */
+		if (rc & WL_TIMEOUT)
+			send_spans_to_otel_collector(&otelContext);
+	}
+
+	/* Curl cleanup */
+	curl_slist_free_all(otelContext.headers);
+	otelContext.headers = NULL;
+	if (otelContext.curl)
+	{
+		curl_easy_cleanup(otelContext.curl);
+		otelContext.curl = NULL;
+	}
+	curl_global_cleanup();
+}

--- a/src/pg_tracing_sql_functions.c
+++ b/src/pg_tracing_sql_functions.c
@@ -33,6 +33,8 @@ get_empty_pg_tracing_stats(void)
 	stats.processed_spans = 0;
 	stats.dropped_traces = 0;
 	stats.dropped_spans = 0;
+	stats.otel_sent_spans = 0;
+	stats.otel_failures = 0;
 	stats.last_consume = 0;
 	stats.stats_reset = GetCurrentTimestamp();
 	return stats;
@@ -311,7 +313,7 @@ pg_tracing_spans(PG_FUNCTION_ARGS)
 Datum
 pg_tracing_info(PG_FUNCTION_ARGS)
 {
-#define PG_TRACING_INFO_COLS	6
+#define PG_TRACING_INFO_COLS	8
 	pgTracingStats stats;
 	TupleDesc	tupdesc;
 	Datum		values[PG_TRACING_INFO_COLS] = {0};
@@ -336,6 +338,8 @@ pg_tracing_info(PG_FUNCTION_ARGS)
 	values[i++] = Int64GetDatum(stats.processed_spans);
 	values[i++] = Int64GetDatum(stats.dropped_traces);
 	values[i++] = Int64GetDatum(stats.dropped_spans);
+	values[i++] = Int64GetDatum(stats.otel_sent_spans);
+	values[i++] = Int64GetDatum(stats.otel_failures);
 	values[i++] = TimestampTzGetDatum(stats.last_consume);
 	values[i++] = TimestampTzGetDatum(stats.stats_reset);
 

--- a/src/pg_tracing_sql_functions.c
+++ b/src/pg_tracing_sql_functions.c
@@ -252,12 +252,12 @@ pg_tracing_spans(PG_FUNCTION_ARGS)
 
 	LWLockAcquire(pg_tracing_shared_state->lock, lock_mode);
 	/* There was a new write, reload the text file */
-	if (pg_tracing_shared_state->extent != qbuffer_size)
+	if (pg_tracing_shared_state->extent <= qbuffer_size)
 	{
 		free(qbuffer);
 		qbuffer = qtext_load_file(&qbuffer_size);
 	}
-	Assert(pg_tracing_shared_state->extent == qbuffer_size);
+	Assert(pg_tracing_shared_state->extent <= qbuffer_size);
 
 	for (int i = 0; i < shared_spans->end; i++)
 	{

--- a/src/pg_tracing_sql_functions.c
+++ b/src/pg_tracing_sql_functions.c
@@ -16,8 +16,6 @@
 #include "utils/fmgrprotos.h"
 #include "utils/timestamp.h"
 
-#define INT64_HEX_FORMAT "%016" INT64_MODIFIER "x"
-
 PG_FUNCTION_INFO_V1(pg_tracing_info);
 PG_FUNCTION_INFO_V1(pg_tracing_spans);
 PG_FUNCTION_INFO_V1(pg_tracing_reset);

--- a/t/001_basic.pl
+++ b/t/001_basic.pl
@@ -1,0 +1,60 @@
+use strict;
+use warnings;
+
+use PostgreSQL::Test::Cluster;
+use PostgreSQL::Test::Utils;
+use Test::More;
+
+my $node = PostgreSQL::Test::Cluster->new('main');
+
+# perl -MCPAN -e 'install -force HTTP::Server::Simple'
+{
+    package TestWebServer;
+
+    use HTTP::Server::Simple::CGI;
+    use base qw(HTTP::Server::Simple::CGI);
+
+    sub handle_request {
+        print "HTTP/1.0 200 OK\r\n";
+    }
+}
+# Start test http server that will receive spans
+my $webserver_pid = TestWebServer->new(4318)->background();
+
+$SIG{TERM} = $SIG{INT} = sub {
+    kill 'INT', $webserver_pid;
+    die "death by signal";
+};
+
+$node->init;
+$node->append_conf(
+	'postgresql.conf',
+	qq{shared_preload_libraries = 'pg_tracing'
+    pg_tracing.otel_naptime = 1000
+    pg_tracing.otel_endpoint = 'http://localhost:4318'
+    log_min_messages = info
+});
+
+$node->start;
+
+# setup
+$node->safe_psql("postgres",
+		"CREATE EXTENSION pg_tracing;");
+
+# Create one span
+$node->safe_psql("postgres", "/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000001-0000000000000001-01'*/SELECT 1;\n");
+
+ok( $node->poll_query_until('postgres',
+        "SELECT otel_sent_spans FROM pg_tracing_info;",
+        4),
+    "Spans were sent to otel collector");
+
+my $result =
+  $node->safe_psql('postgres', "SELECT count(*) FROM pg_tracing_peek_spans;");
+is($result, qq(0), 'All spans should have been consumed');
+
+# Cleanup
+$node->stop;
+kill 'INT', $webserver_pid;
+
+done_testing();

--- a/t/002_connect_timeout.pl
+++ b/t/002_connect_timeout.pl
@@ -1,0 +1,34 @@
+use strict;
+use warnings;
+
+use PostgreSQL::Test::Cluster;
+use PostgreSQL::Test::Utils;
+use Test::More;
+
+my $node = PostgreSQL::Test::Cluster->new('main');
+
+$node->init;
+$node->append_conf(
+	'postgresql.conf',
+	qq{shared_preload_libraries = 'pg_tracing'
+    pg_tracing.otel_naptime = 1000
+    pg_tracing.otel_endpoint = 'http://127.0.100.100:5555'
+    log_min_messages = info
+});
+
+$node->start;
+
+# setup
+$node->safe_psql("postgres",
+		"CREATE EXTENSION pg_tracing;");
+
+# Create one span
+$node->safe_psql("postgres", "/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000001-0000000000000001-01'*/SELECT 1;\n");
+
+ok( $node->poll_query_until('postgres', "SELECT otel_failures >= 1 FROM pg_tracing_info;"),
+    "Otel failures should be reported");
+
+# Cleanup
+$node->stop;
+
+done_testing();


### PR DESCRIPTION
### What does this PR do?
Create a background worker for  that will export send spans to a otel collector at regular interval.
Spans are consumed by the worker from the shared_spans buffer and sent as json using http1 with libcurl.