### PR TITLE
Refactoring span context

### DIFF
--- a/src/pg_tracing.c
+++ b/src/pg_tracing.c
@@ -1315,18 +1315,16 @@ static PlannedStmt *
 pg_tracing_planner_hook(Query *query, const char *query_string, int cursorOptions,
 						ParamListInfo params)
 {
-	Traceparent *traceparent;
 	SpanContext span_context;
 	PlannedStmt *result;
 	TimestampTz span_end_time;
+	Traceparent *traceparent = &parse_traceparent;
 
 	/*
 	 * For nested planning (parse sampled and executor not sampled), we need
 	 * to use parse_traceparent.
 	 */
 	bool		is_nested_planning = nested_level > 0 && !executor_traceparent.sampled && parse_traceparent.sampled;
-
-	traceparent = &parse_traceparent;
 
 	if (nested_level > 0 && !is_nested_planning)
 	{
@@ -1406,11 +1404,9 @@ pg_tracing_planner_hook(Query *query, const char *query_string, int cursorOption
 static void
 pg_tracing_ExecutorStart(QueryDesc *queryDesc, int eflags)
 {
-	Traceparent *traceparent;
 	SpanContext span_context;
 	bool		is_lazy_function;
-
-	traceparent = &executor_traceparent;
+	Traceparent *traceparent = &executor_traceparent;
 
 	if (nested_level == 0)
 	{
@@ -1490,12 +1486,11 @@ static void
 pg_tracing_ExecutorRun(QueryDesc *queryDesc, ScanDirection direction, uint64 count,
 					   bool execute_once)
 {
-	Traceparent *traceparent;
 	SpanContext span_context;
 	TimestampTz span_end_time;
 	Span	   *executor_run_span;
+	Traceparent *traceparent = &executor_traceparent;
 
-	traceparent = &executor_traceparent;
 	if (!pg_tracing_enabled(traceparent, nested_level) || queryDesc->totaltime == NULL)
 	{
 		/* No sampling, go through normal execution */
@@ -1600,12 +1595,11 @@ pg_tracing_ExecutorRun(QueryDesc *queryDesc, ScanDirection direction, uint64 cou
 static void
 pg_tracing_ExecutorFinish(QueryDesc *queryDesc)
 {
-	Traceparent *traceparent;
 	SpanContext span_context;
 	TimestampTz span_end_time;
 	int			num_stored_spans = 0;
+	Traceparent *traceparent = &executor_traceparent;
 
-	traceparent = &executor_traceparent;
 	if (!pg_tracing_enabled(traceparent, nested_level)
 		|| queryDesc->totaltime == NULL
 		|| current_trace_spans == NULL)
@@ -1703,9 +1697,9 @@ pg_tracing_ExecutorFinish(QueryDesc *queryDesc)
 static void
 pg_tracing_ExecutorEnd(QueryDesc *queryDesc)
 {
-	Traceparent *traceparent = &executor_traceparent;
 	TimestampTz parent_end;
 	TimestampTz span_end_time;
+	Traceparent *traceparent = &executor_traceparent;
 
 	if (!pg_tracing_enabled(traceparent, nested_level) || queryDesc->totaltime == NULL)
 	{
@@ -1749,13 +1743,11 @@ pg_tracing_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 						  ParamListInfo params, QueryEnvironment *queryEnv,
 						  DestReceiver *dest, QueryCompletion *qc)
 {
-	Traceparent *traceparent;
 	TimestampTz span_end_time;
 	SpanContext span_context;
 	bool		track_utility;
 	bool		in_aborted_transaction;
-
-	traceparent = &executor_traceparent;
+	Traceparent *traceparent = &executor_traceparent;
 
 	if (nested_level == 0)
 	{

--- a/src/pg_tracing.c
+++ b/src/pg_tracing.c
@@ -1219,6 +1219,7 @@ initialise_span_context(SpanContext * span_context,
 	span_context->query = query;
 	span_context->jstate = jstate;
 	span_context->query_text = query_text;
+	span_context->export_parameters = pg_tracing_export_parameters;
 }
 
 /*
@@ -1294,7 +1295,7 @@ pg_tracing_post_parse_analyze(ParseState *pstate, Query *query, JumbleState *jst
 	initialize_trace_level();
 	initialise_span_context(&span_context, traceparent, NULL, jstate, query, pstate->p_sourcetext);
 	push_active_span(pg_tracing_mem_ctx, &span_context, command_type_to_span_type(query->commandType),
-					 HOOK_PARSE, pg_tracing_export_parameters);
+					 HOOK_PARSE);
 }
 
 /*
@@ -1345,7 +1346,7 @@ pg_tracing_planner_hook(Query *query, const char *query_string, int cursorOption
 	initialize_trace_level();
 	initialise_span_context(&span_context, traceparent, NULL, NULL, query, query_string);
 	push_active_span(pg_tracing_mem_ctx, &span_context, command_type_to_span_type(query->commandType),
-					 HOOK_PLANNER, pg_tracing_export_parameters);
+					 HOOK_PLANNER);
 	/* Create and start the planner span */
 	push_child_active_span(pg_tracing_mem_ctx, &span_context, SPAN_PLANNER, query);
 
@@ -1441,7 +1442,7 @@ pg_tracing_ExecutorStart(QueryDesc *queryDesc, int eflags)
 	initialize_trace_level();
 	initialise_span_context(&span_context, traceparent, queryDesc->plannedstmt, NULL, NULL, queryDesc->sourceText);
 	push_active_span(pg_tracing_mem_ctx, &span_context, command_type_to_span_type(queryDesc->operation),
-					 HOOK_EXECUTOR, pg_tracing_export_parameters);
+					 HOOK_EXECUTOR);
 
 	/*
 	 * We only need full instrumentation if we generate spans from planstate.
@@ -1511,7 +1512,7 @@ pg_tracing_ExecutorRun(QueryDesc *queryDesc, ScanDirection direction, uint64 cou
 	initialize_trace_level();
 	initialise_span_context(&span_context, traceparent, queryDesc->plannedstmt, NULL, NULL, queryDesc->sourceText);
 	push_active_span(pg_tracing_mem_ctx, &span_context, command_type_to_span_type(queryDesc->operation),
-					 HOOK_EXECUTOR, pg_tracing_export_parameters);
+					 HOOK_EXECUTOR);
 	/* Start ExecutorRun span as a new active span */
 	executor_run_span = push_child_active_span(pg_tracing_mem_ctx, &span_context, SPAN_EXECUTOR_RUN,
 											   NULL);
@@ -1624,7 +1625,7 @@ pg_tracing_ExecutorFinish(QueryDesc *queryDesc)
 	initialize_trace_level();
 	initialise_span_context(&span_context, traceparent, queryDesc->plannedstmt, NULL, NULL, queryDesc->sourceText);
 	push_active_span(pg_tracing_mem_ctx, &span_context, command_type_to_span_type(queryDesc->operation),
-					 HOOK_EXECUTOR, pg_tracing_export_parameters);
+					 HOOK_EXECUTOR);
 	/* Create ExecutorFinish as a new potential top span */
 	push_child_active_span(pg_tracing_mem_ctx, &span_context, SPAN_EXECUTOR_FINISH, NULL);
 
@@ -1811,7 +1812,7 @@ pg_tracing_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 	if (track_utility)
 	{
 		push_active_span(pg_tracing_mem_ctx, &span_context, command_type_to_span_type(pstmt->commandType),
-						 HOOK_EXECUTOR, pg_tracing_export_parameters);
+						 HOOK_EXECUTOR);
 		push_child_active_span(pg_tracing_mem_ctx, &span_context, SPAN_PROCESS_UTILITY, NULL);
 	}
 

--- a/src/pg_tracing.c
+++ b/src/pg_tracing.c
@@ -1213,6 +1213,8 @@ initialise_span_context(SpanContext * span_context,
 						const JumbleState *jstate,
 						Query *query, const char *query_text)
 {
+	Assert(pstmt || query);
+
 	span_context->start_time = GetCurrentTimestamp();
 	span_context->traceparent = traceparent;
 	span_context->pstmt = pstmt;
@@ -1220,6 +1222,11 @@ initialise_span_context(SpanContext * span_context,
 	span_context->jstate = jstate;
 	span_context->query_text = query_text;
 	span_context->export_parameters = pg_tracing_export_parameters;
+
+	if (span_context->pstmt)
+		span_context->query_id = pstmt->queryId;
+	else
+		span_context->query_id = query->queryId;
 }
 
 /*

--- a/src/pg_tracing.c
+++ b/src/pg_tracing.c
@@ -1519,7 +1519,7 @@ pg_tracing_ExecutorRun(QueryDesc *queryDesc, ScanDirection direction, uint64 cou
 	 * ExecProcNode override.
 	 */
 	if (pg_tracing_planstate_spans && queryDesc->planstate->instrument)
-		setup_ExecProcNode_override(queryDesc);
+		setup_ExecProcNode_override(pg_tracing_mem_ctx, queryDesc);
 
 	nested_level++;
 	PG_TRY();

--- a/src/pg_tracing.c
+++ b/src/pg_tracing.c
@@ -1913,9 +1913,13 @@ pg_tracing_xact_callback(XactEvent event, void *arg)
 				bool		is_modifying_xact = MyProc->xid != InvalidTransactionId;
 
 				if (traceparent->sampled && is_modifying_xact)
+				{
+					TimestampTz start_time = GetCurrentTimestamp();
+
 					begin_span(traceparent->trace_id, &commit_span,
 							   SPAN_COMMIT, NULL, traceparent->parent_id,
-							   current_query_id, NULL);
+							   current_query_id, start_time);
+				}
 				break;
 			}
 		case XACT_EVENT_COMMIT:

--- a/src/pg_tracing.c
+++ b/src/pg_tracing.c
@@ -1348,7 +1348,7 @@ pg_tracing_planner_hook(Query *query, const char *query_string, int cursorOption
 	push_active_span(pg_tracing_mem_ctx, &span_context, command_type_to_span_type(query->commandType),
 					 HOOK_PLANNER);
 	/* Create and start the planner span */
-	push_child_active_span(pg_tracing_mem_ctx, &span_context, SPAN_PLANNER, query);
+	push_child_active_span(pg_tracing_mem_ctx, &span_context, SPAN_PLANNER);
 
 	nested_level++;
 	PG_TRY();
@@ -1514,8 +1514,7 @@ pg_tracing_ExecutorRun(QueryDesc *queryDesc, ScanDirection direction, uint64 cou
 	push_active_span(pg_tracing_mem_ctx, &span_context, command_type_to_span_type(queryDesc->operation),
 					 HOOK_EXECUTOR);
 	/* Start ExecutorRun span as a new active span */
-	executor_run_span = push_child_active_span(pg_tracing_mem_ctx, &span_context, SPAN_EXECUTOR_RUN,
-											   NULL);
+	executor_run_span = push_child_active_span(pg_tracing_mem_ctx, &span_context, SPAN_EXECUTOR_RUN);
 
 	per_level_infos[nested_level].executor_run_span_id = executor_run_span->span_id;
 	per_level_infos[nested_level].executor_start = executor_run_span->start;
@@ -1627,7 +1626,7 @@ pg_tracing_ExecutorFinish(QueryDesc *queryDesc)
 	push_active_span(pg_tracing_mem_ctx, &span_context, command_type_to_span_type(queryDesc->operation),
 					 HOOK_EXECUTOR);
 	/* Create ExecutorFinish as a new potential top span */
-	push_child_active_span(pg_tracing_mem_ctx, &span_context, SPAN_EXECUTOR_FINISH, NULL);
+	push_child_active_span(pg_tracing_mem_ctx, &span_context, SPAN_EXECUTOR_FINISH);
 
 	/*
 	 * Save the initial number of spans for the current session. We will only
@@ -1813,7 +1812,7 @@ pg_tracing_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 	{
 		push_active_span(pg_tracing_mem_ctx, &span_context, command_type_to_span_type(pstmt->commandType),
 						 HOOK_EXECUTOR);
-		push_child_active_span(pg_tracing_mem_ctx, &span_context, SPAN_PROCESS_UTILITY, NULL);
+		push_child_active_span(pg_tracing_mem_ctx, &span_context, SPAN_PROCESS_UTILITY);
 	}
 
 	nested_level++;

--- a/src/pg_tracing.c
+++ b/src/pg_tracing.c
@@ -1369,7 +1369,7 @@ pg_tracing_planner_hook(Query *query, const char *query_string, int cursorOption
 	{
 		nested_level--;
 		span_end_time = GetCurrentTimestamp();
-		handle_pg_error(span_context.traceparent, NULL, span_end_time);
+		handle_pg_error(traceparent, NULL, span_end_time);
 		PG_RE_THROW();
 	}
 	PG_END_TRY();

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -265,7 +265,7 @@ extern void
 							  TimestampTz parent_start, TimestampTz parent_end);
 
 extern void
-			setup_ExecProcNode_override(QueryDesc *queryDesc);
+			setup_ExecProcNode_override(MemoryContext context, QueryDesc *queryDesc);
 extern void
 			cleanup_planstarts(void);
 extern TracedPlanstate *

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -302,8 +302,6 @@ extern bool traceid_zero(TraceId trace_id);
 pgTracingStats get_empty_pg_tracing_stats(void);
 
 /* pg_tracing_active_spans.c */
-Span	   *allocate_new_active_span(void);
-
 Span	   *pop_active_span(const TimestampTz *end_time);
 Span	   *peek_active_span(void);
 Span	   *push_active_span(const pgTracingTraceparent * traceparent, SpanType span_type,

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -238,12 +238,12 @@ typedef struct TracedPlanstate
 /*
  * Store context to marshal spans to json
  */
-typedef struct pgTracingJsonContext
+typedef struct JsonContext
 {
 	StringInfo	str;
 	const char *qbuffer;
 	Size		qbuffer_size;
-}			pgTracingJsonContext;
+}			JsonContext;
 
 typedef struct SpanContext
 {
@@ -336,7 +336,7 @@ extern void
 
 /* pg_tracing_json.c */
 extern void
-			marshal_spans_to_json(const pgTracingJsonContext * json_ctx, const pgTracingSpans * spans);
+			marshal_spans_to_json(const JsonContext * json_ctx, const pgTracingSpans * spans);
 
 /* pg_tracing_otel.c */
 extern void

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -250,6 +250,7 @@ typedef struct SpanContext
 	TimestampTz start_time;
 	Traceparent *traceparent;
 	const PlannedStmt *pstmt;
+	const Query *query;
 }			SpanContext;
 
 /* pg_tracing_explain.c */
@@ -310,8 +311,9 @@ pgTracingStats get_empty_pg_tracing_stats(void);
 /* pg_tracing_active_spans.c */
 Span	   *pop_active_span(const TimestampTz *end_time);
 Span	   *peek_active_span(void);
-Span	   *push_active_span(MemoryContext context, const SpanContext * span_context, SpanType span_type,
-							 const Query *query, JumbleState *jstate,
+Span	   *push_active_span(MemoryContext context, const SpanContext * span_context,
+							 SpanType span_type,
+							 JumbleState *jstate,
 							 const char *query_text,
 							 HookPhase hook_phase, bool export_parameters);
 Span	   *push_child_active_span(MemoryContext context, const SpanContext * span_context,

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -245,6 +245,12 @@ typedef struct pgTracingJsonContext
 	Size		qbuffer_size;
 }			pgTracingJsonContext;
 
+typedef struct SpanContext
+{
+	pgTracingTraceparent *traceparent;
+	TimestampTz start_time;
+}			SpanContext;
+
 /* pg_tracing_explain.c */
 extern const char *plan_to_node_type(const Plan *plan);
 extern const char *plan_to_operation(const planstateTraceContext * planstateTraceContext, const PlanState *planstate, const char *spanName);
@@ -303,13 +309,12 @@ pgTracingStats get_empty_pg_tracing_stats(void);
 /* pg_tracing_active_spans.c */
 Span	   *pop_active_span(const TimestampTz *end_time);
 Span	   *peek_active_span(void);
-Span	   *push_active_span(MemoryContext context, const pgTracingTraceparent * traceparent, SpanType span_type,
+Span	   *push_active_span(MemoryContext context, const SpanContext * span_context, SpanType span_type,
 							 const Query *query, JumbleState *jstate, const PlannedStmt *pstmt,
-							 const char *query_text, TimestampTz start_time,
+							 const char *query_text,
 							 HookPhase hook_phase, bool export_parameters);
-Span	   *push_child_active_span(MemoryContext context, const pgTracingTraceparent * traceparent,
-								   SpanType span_type, const Query *query, const PlannedStmt *pstmt,
-								   TimestampTz start_time);
+Span	   *push_child_active_span(MemoryContext context, const SpanContext * span_context,
+								   SpanType span_type, const Query *query, const PlannedStmt *pstmt);
 
 void		cleanup_active_spans(void);
 

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -253,6 +253,7 @@ typedef struct SpanContext
 	const Query *query;
 	const JumbleState *jstate;
 	const char *query_text;
+	bool		export_parameters;
 }			SpanContext;
 
 /* pg_tracing_explain.c */
@@ -314,8 +315,7 @@ pgTracingStats get_empty_pg_tracing_stats(void);
 Span	   *pop_active_span(const TimestampTz *end_time);
 Span	   *peek_active_span(void);
 Span	   *push_active_span(MemoryContext context, const SpanContext * span_context,
-							 SpanType span_type,
-							 HookPhase hook_phase, bool export_parameters);
+							 SpanType span_type, HookPhase hook_phase);
 Span	   *push_child_active_span(MemoryContext context, const SpanContext * span_context,
 								   SpanType span_type, const Query *query);
 

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -317,7 +317,7 @@ Span	   *peek_active_span(void);
 Span	   *push_active_span(MemoryContext context, const SpanContext * span_context,
 							 SpanType span_type, HookPhase hook_phase);
 Span	   *push_child_active_span(MemoryContext context, const SpanContext * span_context,
-								   SpanType span_type, const Query *query);
+								   SpanType span_type);
 
 void		cleanup_active_spans(void);
 

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -247,8 +247,9 @@ typedef struct JsonContext
 
 typedef struct SpanContext
 {
-	Traceparent *traceparent;
 	TimestampTz start_time;
+	Traceparent *traceparent;
+	const PlannedStmt *pstmt;
 }			SpanContext;
 
 /* pg_tracing_explain.c */

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -253,6 +253,7 @@ typedef struct SpanContext
 	const Query *query;
 	const JumbleState *jstate;
 	const char *query_text;
+	uint64		query_id;
 	bool		export_parameters;
 }			SpanContext;
 

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -304,18 +304,17 @@ pgTracingStats get_empty_pg_tracing_stats(void);
 /* pg_tracing_active_spans.c */
 Span	   *pop_active_span(const TimestampTz *end_time);
 Span	   *peek_active_span(void);
-Span	   *push_active_span(const pgTracingTraceparent * traceparent, SpanType span_type,
+Span	   *push_active_span(MemoryContext context, const pgTracingTraceparent * traceparent, SpanType span_type,
 							 const Query *query, JumbleState *jstate, const PlannedStmt *pstmt,
 							 const char *query_text, TimestampTz start_time,
 							 HookPhase hook_phase, bool export_parameters);
-Span	   *push_child_active_span(const pgTracingTraceparent * traceparent, SpanType span_type,
-								   const Query *query, const PlannedStmt *pstmt,
+Span	   *push_child_active_span(MemoryContext context, const pgTracingTraceparent * traceparent,
+								   SpanType span_type, const Query *query, const PlannedStmt *pstmt,
 								   TimestampTz start_time);
 
 void		cleanup_active_spans(void);
 
 /* pg_tracing.c */
-extern MemoryContext pg_tracing_mem_ctx;
 extern pgTracingSharedState * pg_tracing_shared_state;
 extern pgTracingSpans * shared_spans;
 

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -264,7 +264,7 @@ extern const char *plan_to_deparse_info(const planstateTraceContext * planstateT
 
 /* pg_tracing_parallel.c */
 extern void pg_tracing_shmem_parallel_startup(void);
-extern void add_parallel_context(const struct Traceparent *traceparent, uint64 parent_id);
+extern void add_parallel_context(const Traceparent *traceparent, uint64 parent_id);
 extern void remove_parallel_context(void);
 extern void fetch_parallel_context(Traceparent * traceparent);
 

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -299,8 +299,8 @@ extern char *qtext_load_file(Size *buffer_size);
 
 /* pg_tracing_span.c */
 extern void begin_span(TraceId trace_id, Span * span, SpanType type,
-					   uint64 *span_id, uint64 parent_id, uint64 query_id,
-					   const TimestampTz *start_span);
+					   const uint64 *span_id, uint64 parent_id, uint64 query_id,
+					   TimestampTz start_span);
 extern void end_span(Span * span, const TimestampTz *end_time);
 extern void reset_span(Span * span);
 extern const char *get_span_type(const Span * span, const char *qbuffer, Size qbuffer_size);

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -252,6 +252,7 @@ typedef struct SpanContext
 	const PlannedStmt *pstmt;
 	const Query *query;
 	const JumbleState *jstate;
+	const char *query_text;
 }			SpanContext;
 
 /* pg_tracing_explain.c */
@@ -314,7 +315,6 @@ Span	   *pop_active_span(const TimestampTz *end_time);
 Span	   *peek_active_span(void);
 Span	   *push_active_span(MemoryContext context, const SpanContext * span_context,
 							 SpanType span_type,
-							 const char *query_text,
 							 HookPhase hook_phase, bool export_parameters);
 Span	   *push_child_active_span(MemoryContext context, const SpanContext * span_context,
 								   SpanType span_type, const Query *query);

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -187,12 +187,12 @@ typedef struct planstateTraceContext
 /*
  * Traceparent values propagated by the caller
  */
-typedef struct pgTracingTraceparent
+typedef struct Traceparent
 {
 	TraceId		trace_id;		/* Id of the trace */
 	uint64		parent_id;		/* Span id of the parent */
 	int			sampled;		/* Is current statement sampled? */
-}			pgTracingTraceparent;
+}			Traceparent;
 
 /*
  * A trace context for a specific parallel context
@@ -201,7 +201,7 @@ typedef struct pgTracingParallelContext
 {
 	ProcNumber	leader_backend_id;	/* Backend id of the leader, set to
 									 * InvalidBackendId if unused */
-	pgTracingTraceparent traceparent;
+	Traceparent traceparent;
 }			pgTracingParallelContext;
 
 /*
@@ -247,7 +247,7 @@ typedef struct pgTracingJsonContext
 
 typedef struct SpanContext
 {
-	pgTracingTraceparent *traceparent;
+	Traceparent *traceparent;
 	TimestampTz start_time;
 }			SpanContext;
 
@@ -258,14 +258,14 @@ extern const char *plan_to_deparse_info(const planstateTraceContext * planstateT
 
 /* pg_tracing_parallel.c */
 extern void pg_tracing_shmem_parallel_startup(void);
-extern void add_parallel_context(const struct pgTracingTraceparent *traceparent, uint64 parent_id);
+extern void add_parallel_context(const struct Traceparent *traceparent, uint64 parent_id);
 extern void remove_parallel_context(void);
-extern void fetch_parallel_context(pgTracingTraceparent * traceparent);
+extern void fetch_parallel_context(Traceparent * traceparent);
 
 /* pg_tracing_planstate.c */
 
 extern void
-			process_planstate(const pgTracingTraceparent * traceparent, const QueryDesc *queryDesc,
+			process_planstate(const Traceparent * traceparent, const QueryDesc *queryDesc,
 							  int sql_error_code, bool deparse_plan, uint64 parent_id,
 							  TimestampTz parent_start, TimestampTz parent_end);
 
@@ -284,8 +284,8 @@ extern TimestampTz
 extern const char *normalise_query_parameters(const JumbleState *jstate, const char *query,
 											  int query_loc, int *query_len_p, char **param_str,
 											  int *param_len);
-extern void extract_trace_context_from_query(pgTracingTraceparent * traceparent, const char *query);
-extern void parse_trace_context(pgTracingTraceparent * traceparent, const char *trace_context_str, int trace_context_len);
+extern void extract_trace_context_from_query(Traceparent * traceparent, const char *query);
+extern void parse_trace_context(Traceparent * traceparent, const char *trace_context_str, int trace_context_len);
 extern const char *normalise_query(const char *query, int query_loc, int *query_len_p);
 extern bool text_store_file(pgTracingSharedState * pg_tracing, const char *query,
 							int query_len, Size *query_offset);

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -12,7 +12,6 @@
 #include "executor/execdesc.h"
 #include "jit/jit.h"
 #include "pgstat.h"
-#include "storage/backendid.h"
 #include "storage/lwlock.h"
 #include "version_compat.h"
 

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -251,6 +251,7 @@ typedef struct SpanContext
 	Traceparent *traceparent;
 	const PlannedStmt *pstmt;
 	const Query *query;
+	const JumbleState *jstate;
 }			SpanContext;
 
 /* pg_tracing_explain.c */
@@ -313,7 +314,6 @@ Span	   *pop_active_span(const TimestampTz *end_time);
 Span	   *peek_active_span(void);
 Span	   *push_active_span(MemoryContext context, const SpanContext * span_context,
 							 SpanType span_type,
-							 JumbleState *jstate,
 							 const char *query_text,
 							 HookPhase hook_phase, bool export_parameters);
 Span	   *push_child_active_span(MemoryContext context, const SpanContext * span_context,

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -311,11 +311,11 @@ pgTracingStats get_empty_pg_tracing_stats(void);
 Span	   *pop_active_span(const TimestampTz *end_time);
 Span	   *peek_active_span(void);
 Span	   *push_active_span(MemoryContext context, const SpanContext * span_context, SpanType span_type,
-							 const Query *query, JumbleState *jstate, const PlannedStmt *pstmt,
+							 const Query *query, JumbleState *jstate,
 							 const char *query_text,
 							 HookPhase hook_phase, bool export_parameters);
 Span	   *push_child_active_span(MemoryContext context, const SpanContext * span_context,
-								   SpanType span_type, const Query *query, const PlannedStmt *pstmt);
+								   SpanType span_type, const Query *query);
 
 void		cleanup_active_spans(void);
 

--- a/src/pg_tracing_active_spans.c
+++ b/src/pg_tracing_active_spans.c
@@ -262,14 +262,13 @@ push_child_active_span(MemoryContext context, const SpanContext * span_context,
  */
 Span *
 push_active_span(MemoryContext context, const SpanContext * span_context, SpanType span_type,
-				 const Query *query, JumbleState *jstate,
-				 const char *query_text, HookPhase hook_phase, bool export_parameters)
+				 JumbleState *jstate, const char *query_text, HookPhase hook_phase, bool export_parameters)
 {
 	Span	   *span = peek_active_span_for_current_level();
 	Span	   *parent_span = peek_active_span();
 
 	/* Either query or planned statement should be defined */
-	Assert(query || span_context->pstmt);
+	Assert(span_context->query || span_context->pstmt);
 	if (span == NULL)
 	{
 		/*
@@ -298,7 +297,7 @@ push_active_span(MemoryContext context, const SpanContext * span_context, SpanTy
 		span = &next_active_span;
 	}
 
-	begin_active_span(span_context->traceparent, span, span_type, query, jstate, span_context->pstmt,
+	begin_active_span(span_context->traceparent, span, span_type, span_context->query, jstate, span_context->pstmt,
 					  query_text, span_context->start_time, export_parameters, parent_span);
 	return span;
 }

--- a/src/pg_tracing_active_spans.c
+++ b/src/pg_tracing_active_spans.c
@@ -127,7 +127,7 @@ pop_active_span(const TimestampTz *end_time)
  */
 static void
 begin_active_span(const SpanContext * span_context, Span * span,
-				  SpanType span_type, const Query *query, const JumbleState *jstate,
+				  SpanType span_type, const JumbleState *jstate,
 				  const PlannedStmt *pstmt, const char *query_text,
 				  bool export_parameters, Span * parent_span)
 {
@@ -136,6 +136,7 @@ begin_active_span(const SpanContext * span_context, Span * span,
 	uint64		parent_id;
 	int8		parent_planstate_index = -1;
 	uint64		query_id;
+    const Query *query = span_context->query;
 
 	if (nested_level == 0)
 		/* Root active span, use the parent id from the trace context */
@@ -167,7 +168,7 @@ begin_active_span(const SpanContext * span_context, Span * span,
 	if (pstmt)
 		query_id = pstmt->queryId;
 	else
-		query_id = query->queryId;
+		query_id = span_context->query->queryId;
 
 	begin_span(span_context->traceparent->trace_id, span, span_type,
 			   NULL, parent_id, query_id, &span_context->start_time);
@@ -297,7 +298,7 @@ push_active_span(MemoryContext context, const SpanContext * span_context, SpanTy
 		span = &next_active_span;
 	}
 
-	begin_active_span(span_context, span, span_type, span_context->query, jstate, span_context->pstmt,
+	begin_active_span(span_context, span, span_type, jstate, span_context->pstmt,
 					  query_text, export_parameters, parent_span);
 	return span;
 }

--- a/src/pg_tracing_active_spans.c
+++ b/src/pg_tracing_active_spans.c
@@ -233,14 +233,14 @@ begin_active_span(const Traceparent * traceparent, Span * span,
  */
 Span *
 push_child_active_span(MemoryContext context, const SpanContext * span_context,
-					   SpanType span_type, const Query *query, const PlannedStmt *pstmt)
+					   SpanType span_type, const Query *query)
 {
 	Span	   *parent_span = peek_active_span();
 	Span	   *span = allocate_new_active_span(context);
 	uint64		query_id;
 
-	if (pstmt)
-		query_id = pstmt->queryId;
+	if (span_context->pstmt)
+		query_id = span_context->pstmt->queryId;
 	else
 		query_id = query->queryId;
 
@@ -262,14 +262,14 @@ push_child_active_span(MemoryContext context, const SpanContext * span_context,
  */
 Span *
 push_active_span(MemoryContext context, const SpanContext * span_context, SpanType span_type,
-				 const Query *query, JumbleState *jstate, const PlannedStmt *pstmt,
+				 const Query *query, JumbleState *jstate,
 				 const char *query_text, HookPhase hook_phase, bool export_parameters)
 {
 	Span	   *span = peek_active_span_for_current_level();
 	Span	   *parent_span = peek_active_span();
 
 	/* Either query or planned statement should be defined */
-	Assert(query || pstmt);
+	Assert(query || span_context->pstmt);
 	if (span == NULL)
 	{
 		/*
@@ -298,7 +298,7 @@ push_active_span(MemoryContext context, const SpanContext * span_context, SpanTy
 		span = &next_active_span;
 	}
 
-	begin_active_span(span_context->traceparent, span, span_type, query, jstate, pstmt,
+	begin_active_span(span_context->traceparent, span, span_type, query, jstate, span_context->pstmt,
 					  query_text, span_context->start_time, export_parameters, parent_span);
 	return span;
 }

--- a/src/pg_tracing_active_spans.c
+++ b/src/pg_tracing_active_spans.c
@@ -44,7 +44,7 @@ cleanup_active_spans(void)
 /*
  * Push a new active span to the active_spans stack
  */
-Span *
+static Span *
 allocate_new_active_span(void)
 {
 	Span	   *span;

--- a/src/pg_tracing_active_spans.c
+++ b/src/pg_tracing_active_spans.c
@@ -135,7 +135,6 @@ begin_active_span(const SpanContext * span_context, Span * span,
 	const char *normalised_query;
 	uint64		parent_id;
 	int8		parent_planstate_index = -1;
-	uint64		query_id;
 
 	if (nested_level == 0)
 		/* Root active span, use the parent id from the trace context */
@@ -164,13 +163,8 @@ begin_active_span(const SpanContext * span_context, Span * span,
 			parent_id = parent_span->span_id;
 	}
 
-	if (pstmt)
-		query_id = pstmt->queryId;
-	else
-		query_id = query->queryId;
-
 	begin_span(span_context->traceparent->trace_id, span, span_type,
-			   NULL, parent_id, query_id, &span_context->start_time);
+			   NULL, parent_id, span_context->query_id, &span_context->start_time);
 	/* Keep track of the parent planstate index */
 	span->parent_planstate_index = parent_planstate_index;
 
@@ -237,15 +231,9 @@ push_child_active_span(MemoryContext context, const SpanContext * span_context,
 {
 	Span	   *parent_span = peek_active_span();
 	Span	   *span = allocate_new_active_span(context);
-	uint64		query_id;
-
-	if (span_context->pstmt)
-		query_id = span_context->pstmt->queryId;
-	else
-		query_id = span_context->query->queryId;
 
 	begin_span(span_context->traceparent->trace_id, span, span_type, NULL,
-			   parent_span->span_id, query_id, &span_context->start_time);
+			   parent_span->span_id, span_context->query_id, &span_context->start_time);
 	return span;
 }
 

--- a/src/pg_tracing_active_spans.c
+++ b/src/pg_tracing_active_spans.c
@@ -233,7 +233,7 @@ begin_active_span(const SpanContext * span_context, Span * span,
  */
 Span *
 push_child_active_span(MemoryContext context, const SpanContext * span_context,
-					   SpanType span_type, const Query *query)
+					   SpanType span_type)
 {
 	Span	   *parent_span = peek_active_span();
 	Span	   *span = allocate_new_active_span(context);
@@ -242,7 +242,7 @@ push_child_active_span(MemoryContext context, const SpanContext * span_context,
 	if (span_context->pstmt)
 		query_id = span_context->pstmt->queryId;
 	else
-		query_id = query->queryId;
+		query_id = span_context->query->queryId;
 
 	begin_span(span_context->traceparent->trace_id, span, span_type, NULL,
 			   parent_span->span_id, query_id, &span_context->start_time);

--- a/src/pg_tracing_active_spans.c
+++ b/src/pg_tracing_active_spans.c
@@ -127,8 +127,7 @@ pop_active_span(const TimestampTz *end_time)
  */
 static void
 begin_active_span(const SpanContext * span_context, Span * span,
-				  SpanType span_type, bool export_parameters,
-				  Span * parent_span)
+				  SpanType span_type, Span * parent_span)
 {
 	const Query *query = span_context->query;
 	const PlannedStmt *pstmt = span_context->pstmt;
@@ -196,7 +195,7 @@ begin_active_span(const SpanContext * span_context, Span * span,
 													  query->stmt_location, &query_len,
 													  &param_str, &param_len);
 		Assert(param_len > 0);
-		if (export_parameters)
+		if (span_context->export_parameters)
 			span->parameter_offset = add_str_to_trace_buffer(param_str, param_len);
 	}
 	else
@@ -263,7 +262,7 @@ push_child_active_span(MemoryContext context, const SpanContext * span_context,
  */
 Span *
 push_active_span(MemoryContext context, const SpanContext * span_context, SpanType span_type,
-				 HookPhase hook_phase, bool export_parameters)
+				 HookPhase hook_phase)
 {
 	Span	   *span = peek_active_span_for_current_level();
 	Span	   *parent_span = peek_active_span();
@@ -298,6 +297,6 @@ push_active_span(MemoryContext context, const SpanContext * span_context, SpanTy
 		span = &next_active_span;
 	}
 
-	begin_active_span(span_context, span, span_type, export_parameters, parent_span);
+	begin_active_span(span_context, span, span_type, parent_span);
 	return span;
 }

--- a/src/pg_tracing_active_spans.c
+++ b/src/pg_tracing_active_spans.c
@@ -255,8 +255,6 @@ push_active_span(MemoryContext context, const SpanContext * span_context, SpanTy
 	Span	   *span = peek_active_span_for_current_level();
 	Span	   *parent_span = peek_active_span();
 
-	/* Either query or planned statement should be defined */
-	Assert(span_context->query || span_context->pstmt);
 	if (span == NULL)
 	{
 		/*

--- a/src/pg_tracing_active_spans.c
+++ b/src/pg_tracing_active_spans.c
@@ -128,15 +128,15 @@ pop_active_span(const TimestampTz *end_time)
 static void
 begin_active_span(const SpanContext * span_context, Span * span,
 				  SpanType span_type, const JumbleState *jstate,
-				  const PlannedStmt *pstmt, const char *query_text,
-				  bool export_parameters, Span * parent_span)
+                  const char *query_text, bool export_parameters, Span * parent_span)
 {
+    const Query *query = span_context->query;
+    const PlannedStmt *pstmt = span_context->pstmt;
 	int			query_len;
 	const char *normalised_query;
 	uint64		parent_id;
 	int8		parent_planstate_index = -1;
 	uint64		query_id;
-    const Query *query = span_context->query;
 
 	if (nested_level == 0)
 		/* Root active span, use the parent id from the trace context */
@@ -168,7 +168,7 @@ begin_active_span(const SpanContext * span_context, Span * span,
 	if (pstmt)
 		query_id = pstmt->queryId;
 	else
-		query_id = span_context->query->queryId;
+		query_id = query->queryId;
 
 	begin_span(span_context->traceparent->trace_id, span, span_type,
 			   NULL, parent_id, query_id, &span_context->start_time);
@@ -298,7 +298,7 @@ push_active_span(MemoryContext context, const SpanContext * span_context, SpanTy
 		span = &next_active_span;
 	}
 
-	begin_active_span(span_context, span, span_type, jstate, span_context->pstmt,
+	begin_active_span(span_context, span, span_type, jstate,
 					  query_text, export_parameters, parent_span);
 	return span;
 }

--- a/src/pg_tracing_active_spans.c
+++ b/src/pg_tracing_active_spans.c
@@ -164,7 +164,7 @@ begin_active_span(const SpanContext * span_context, Span * span,
 	}
 
 	begin_span(span_context->traceparent->trace_id, span, span_type,
-			   NULL, parent_id, span_context->query_id, &span_context->start_time);
+			   NULL, parent_id, span_context->query_id, span_context->start_time);
 	/* Keep track of the parent planstate index */
 	span->parent_planstate_index = parent_planstate_index;
 
@@ -233,7 +233,7 @@ push_child_active_span(MemoryContext context, const SpanContext * span_context,
 	Span	   *span = allocate_new_active_span(context);
 
 	begin_span(span_context->traceparent->trace_id, span, span_type, NULL,
-			   parent_span->span_id, span_context->query_id, &span_context->start_time);
+			   parent_span->span_id, span_context->query_id, span_context->start_time);
 	return span;
 }
 

--- a/src/pg_tracing_active_spans.c
+++ b/src/pg_tracing_active_spans.c
@@ -126,9 +126,9 @@ pop_active_span(const TimestampTz *end_time)
  * span at the same level ended.
  */
 static void
-begin_active_span(const Traceparent * traceparent, Span * span,
+begin_active_span(const SpanContext * span_context, Span * span,
 				  SpanType span_type, const Query *query, const JumbleState *jstate,
-				  const PlannedStmt *pstmt, const char *query_text, TimestampTz start_time,
+				  const PlannedStmt *pstmt, const char *query_text,
 				  bool export_parameters, Span * parent_span)
 {
 	int			query_len;
@@ -139,7 +139,7 @@ begin_active_span(const Traceparent * traceparent, Span * span,
 
 	if (nested_level == 0)
 		/* Root active span, use the parent id from the trace context */
-		parent_id = traceparent->parent_id;
+		parent_id = span_context->traceparent->parent_id;
 	else
 	{
 		TracedPlanstate *parent_traced_planstate = NULL;
@@ -169,8 +169,8 @@ begin_active_span(const Traceparent * traceparent, Span * span,
 	else
 		query_id = query->queryId;
 
-	begin_span(traceparent->trace_id, span, span_type,
-			   NULL, parent_id, query_id, &start_time);
+	begin_span(span_context->traceparent->trace_id, span, span_type,
+			   NULL, parent_id, query_id, &span_context->start_time);
 	/* Keep track of the parent planstate index */
 	span->parent_planstate_index = parent_planstate_index;
 
@@ -297,7 +297,7 @@ push_active_span(MemoryContext context, const SpanContext * span_context, SpanTy
 		span = &next_active_span;
 	}
 
-	begin_active_span(span_context->traceparent, span, span_type, span_context->query, jstate, span_context->pstmt,
-					  query_text, span_context->start_time, export_parameters, parent_span);
+	begin_active_span(span_context, span, span_type, span_context->query, jstate, span_context->pstmt,
+					  query_text, export_parameters, parent_span);
 	return span;
 }

--- a/src/pg_tracing_active_spans.c
+++ b/src/pg_tracing_active_spans.c
@@ -127,11 +127,11 @@ pop_active_span(const TimestampTz *end_time)
  */
 static void
 begin_active_span(const SpanContext * span_context, Span * span,
-				  SpanType span_type, const JumbleState *jstate,
-                  const char *query_text, bool export_parameters, Span * parent_span)
+				  SpanType span_type, const char *query_text, bool export_parameters,
+				  Span * parent_span)
 {
-    const Query *query = span_context->query;
-    const PlannedStmt *pstmt = span_context->pstmt;
+	const Query *query = span_context->query;
+	const PlannedStmt *pstmt = span_context->pstmt;
 	int			query_len;
 	const char *normalised_query;
 	uint64		parent_id;
@@ -185,14 +185,14 @@ begin_active_span(const SpanContext * span_context, Span * span,
 		return;
 	}
 
-	if (jstate && jstate->clocations_count > 0 && query != NULL)
+	if (span_context->jstate && span_context->jstate->clocations_count > 0 && query != NULL)
 	{
 		/* jstate is available, normalise query and extract parameters' values */
 		char	   *param_str;
 		int			param_len;
 
 		query_len = query->stmt_len;
-		normalised_query = normalise_query_parameters(jstate, query_text,
+		normalised_query = normalise_query_parameters(span_context->jstate, query_text,
 													  query->stmt_location, &query_len,
 													  &param_str, &param_len);
 		Assert(param_len > 0);
@@ -263,7 +263,7 @@ push_child_active_span(MemoryContext context, const SpanContext * span_context,
  */
 Span *
 push_active_span(MemoryContext context, const SpanContext * span_context, SpanType span_type,
-				 JumbleState *jstate, const char *query_text, HookPhase hook_phase, bool export_parameters)
+				 const char *query_text, HookPhase hook_phase, bool export_parameters)
 {
 	Span	   *span = peek_active_span_for_current_level();
 	Span	   *parent_span = peek_active_span();
@@ -298,7 +298,7 @@ push_active_span(MemoryContext context, const SpanContext * span_context, SpanTy
 		span = &next_active_span;
 	}
 
-	begin_active_span(span_context, span, span_type, jstate,
+	begin_active_span(span_context, span, span_type,
 					  query_text, export_parameters, parent_span);
 	return span;
 }

--- a/src/pg_tracing_active_spans.c
+++ b/src/pg_tracing_active_spans.c
@@ -126,7 +126,7 @@ pop_active_span(const TimestampTz *end_time)
  * span at the same level ended.
  */
 static void
-begin_active_span(const pgTracingTraceparent * traceparent, Span * span,
+begin_active_span(const Traceparent * traceparent, Span * span,
 				  SpanType span_type, const Query *query, const JumbleState *jstate,
 				  const PlannedStmt *pstmt, const char *query_text, TimestampTz start_time,
 				  bool export_parameters, Span * parent_span)

--- a/src/pg_tracing_active_spans.c
+++ b/src/pg_tracing_active_spans.c
@@ -51,24 +51,18 @@ allocate_new_active_span(void)
 
 	if (active_spans == NULL)
 	{
-		MemoryContext oldcxt;
-
-		oldcxt = MemoryContextSwitchTo(pg_tracing_mem_ctx);
-		active_spans = palloc0(sizeof(pgTracingSpans) + 10 * sizeof(Span));
-		MemoryContextSwitchTo(oldcxt);
+		active_spans = MemoryContextAllocZero(pg_tracing_mem_ctx,
+											  sizeof(pgTracingSpans) + 10 * sizeof(Span));
 		active_spans->max = 10;
 	}
 	else if (active_spans->end >= active_spans->max)
 	{
-		MemoryContext oldcxt;
 		int			old_spans_max = active_spans->max;
 
 		active_spans->max *= 2;
-		oldcxt = MemoryContextSwitchTo(pg_tracing_mem_ctx);
 		active_spans = repalloc0(active_spans,
 								 sizeof(pgTracingSpans) + old_spans_max * sizeof(Span),
 								 sizeof(pgTracingSpans) + old_spans_max * 2 * sizeof(Span));
-		MemoryContextSwitchTo(oldcxt);
 	}
 
 	span = &active_spans->spans[active_spans->end++];

--- a/src/pg_tracing_json.c
+++ b/src/pg_tracing_json.c
@@ -207,7 +207,7 @@ append_span_attributes(StringInfo str, const Span * span)
 }
 
 static void
-append_span(const pgTracingJsonContext * json_ctx, const Span * span)
+append_span(const JsonContext * json_ctx, const Span * span)
 {
 	char		trace_id[33];
 	char		parent_id[17];
@@ -236,7 +236,7 @@ append_span(const pgTracingJsonContext * json_ctx, const Span * span)
 }
 
 static void
-append_scope_spans(const pgTracingJsonContext * json_ctx, const pgTracingSpans * spans)
+append_scope_spans(const JsonContext * json_ctx, const pgTracingSpans * spans)
 {
 	appendStringInfo(json_ctx->str, "\"scopeSpans\":[");
 	appendStringInfo(json_ctx->str, "{\"spans\": [");
@@ -253,7 +253,7 @@ append_scope_spans(const pgTracingJsonContext * json_ctx, const pgTracingSpans *
  * Marshal spans json compatible for otel http endpoint
  */
 void
-marshal_spans_to_json(const pgTracingJsonContext * json_ctx, const pgTracingSpans * spans)
+marshal_spans_to_json(const JsonContext * json_ctx, const pgTracingSpans * spans)
 {
 	appendStringInfo(json_ctx->str, "{\"resourceSpans\": [{");
 	append_resource(json_ctx->str);

--- a/src/pg_tracing_otel.c
+++ b/src/pg_tracing_otel.c
@@ -123,7 +123,7 @@ send_spans_to_otel_collector(OtelContext * octx)
 	int			num_spans = 0;
 	char	   *qbuffer;
 	Size		qbuffer_size = 0;
-	pgTracingJsonContext json_ctx;
+	JsonContext json_ctx;
 	StringInfoData str;
 
 	/*

--- a/src/pg_tracing_parallel.c
+++ b/src/pg_tracing_parallel.c
@@ -44,7 +44,7 @@ pg_tracing_shmem_parallel_startup(void)
  * Push trace context to the shared parallel worker buffer
  */
 void
-add_parallel_context(const pgTracingTraceparent * traceparent, uint64 parent_id)
+add_parallel_context(const Traceparent * traceparent, uint64 parent_id)
 {
 	pgTracingParallelContext *ctx = NULL;
 
@@ -93,7 +93,7 @@ remove_parallel_context(void)
  * If a trace context exists, it means that the query is sampled and worker tracing is enabled.
  */
 void
-fetch_parallel_context(pgTracingTraceparent * traceparent)
+fetch_parallel_context(Traceparent * traceparent)
 {
 	SpinLockAcquire(&pg_tracing_parallel->mutex);
 	for (int i = 0; i < max_parallel_workers; i++)

--- a/src/pg_tracing_planstate.c
+++ b/src/pg_tracing_planstate.c
@@ -180,16 +180,13 @@ ExecProcNodeFirstPgTracing(PlanState *node)
 		 * We need to extend the traced_planstates array, switch to pg_tracing
 		 * memory context beforehand
 		 */
-		MemoryContext oldcxt;
 		int			old_max_planstart = max_planstart;
 
 		Assert(traced_planstates != NULL);
 		max_planstart += INCREMENT_NUM_PLANSTATE;
-		oldcxt = MemoryContextSwitchTo(pg_tracing_mem_ctx);
 		traced_planstates = repalloc0(traced_planstates,
 									  old_max_planstart * sizeof(TracedPlanstate),
 									  max_planstart * sizeof(TracedPlanstate));
-		MemoryContextSwitchTo(oldcxt);
 	}
 
 	/* Register planstate start */

--- a/src/pg_tracing_planstate.c
+++ b/src/pg_tracing_planstate.c
@@ -655,7 +655,7 @@ create_span_node(PlanState *planstate, const planstateTraceContext * planstateTr
  * Process planstate to generate spans of the executed plan
  */
 void
-process_planstate(const pgTracingTraceparent * traceparent, const QueryDesc *queryDesc,
+process_planstate(const Traceparent * traceparent, const QueryDesc *queryDesc,
 				  int sql_error_code, bool deparse_plan, uint64 parent_id,
 				  TimestampTz parent_start, TimestampTz parent_end)
 {

--- a/src/pg_tracing_planstate.c
+++ b/src/pg_tracing_planstate.c
@@ -302,16 +302,13 @@ override_ExecProcNode(PlanState *planstate)
  * Override all ExecProcNode pointer of the planstate with ExecProcNodeFirstPgTracing to track first call of a node.
  */
 void
-setup_ExecProcNode_override(QueryDesc *queryDesc)
+setup_ExecProcNode_override(MemoryContext context, QueryDesc *queryDesc)
 {
 	if (max_planstart == 0)
 	{
-		MemoryContext oldcxt;
-
 		max_planstart = INITIAL_NUM_PLANSTATE;
-		oldcxt = MemoryContextSwitchTo(pg_tracing_mem_ctx);
-		traced_planstates = palloc0(max_planstart * sizeof(TracedPlanstate));
-		MemoryContextSwitchTo(oldcxt);
+		traced_planstates = MemoryContextAllocZero(context,
+												   max_planstart * sizeof(TracedPlanstate));
 	}
 	Assert(queryDesc->planstate->instrument);
 	/* Pointer should target ExecProcNodeFirst. Save it to restore it later. */

--- a/src/pg_tracing_planstate.c
+++ b/src/pg_tracing_planstate.c
@@ -603,7 +603,7 @@ create_span_node(PlanState *planstate, const planstateTraceContext * planstateTr
 	Assert(planstate->instrument->total > 0);
 
 	begin_span(planstateTraceContext->trace_id, &span, span_type, span_id, parent_id,
-			   query_id, &span_start);
+			   query_id, span_start);
 
 	/* first tuple time */
 	span.startup = planstate->instrument->startup * NS_PER_S;

--- a/src/pg_tracing_query_process.c
+++ b/src/pg_tracing_query_process.c
@@ -58,10 +58,10 @@ has_possible_sql_comment(const char *query)
  * The expected format for traceparent is: version-traceid-parentid-sampled
  * Example: 00-00000000000000000000000000000009-0000000000000005-01
  */
-static pgTracingTraceparent
+static Traceparent
 parse_traceparent_value(const char *traceparent_str)
 {
-	pgTracingTraceparent traceparent;
+	Traceparent traceparent;
 	char	   *traceid_left;
 	char	   *endptr;
 
@@ -105,7 +105,7 @@ parse_traceparent_value(const char *traceparent_str)
  * Or "SELECT 1 /\*traceparent='00-00000000000000000000000000000009-0000000000000005-01'*\/;"
  */
 void
-extract_trace_context_from_query(pgTracingTraceparent * traceparent,
+extract_trace_context_from_query(Traceparent * traceparent,
 								 const char *query)
 {
 	const char *start_sqlcomment = NULL;
@@ -146,7 +146,7 @@ extract_trace_context_from_query(pgTracingTraceparent * traceparent,
  * We're only interested in traceparent value to get the trace id, parent id and sampled flag.
  */
 void
-parse_trace_context(pgTracingTraceparent * traceparent, const char *trace_context_str,
+parse_trace_context(Traceparent * traceparent, const char *trace_context_str,
 					int trace_context_len)
 {
 	const char *traceparent_str;

--- a/src/pg_tracing_span.c
+++ b/src/pg_tracing_span.c
@@ -11,7 +11,7 @@
 #include "postgres.h"
 
 #include "common/pg_prng.h"
-#include "nodes/extensible.h"
+#include "storage/proc.h"
 #include "pg_tracing.h"
 
 /*

--- a/src/pg_tracing_span.c
+++ b/src/pg_tracing_span.c
@@ -68,20 +68,11 @@ initialize_span_fields(Span * span, SpanType type, TraceId trace_id, const uint6
  */
 void
 begin_span(TraceId trace_id, Span * span, SpanType type,
-		   uint64 *span_id, uint64 parent_id, uint64 query_id,
-		   const TimestampTz *start_span)
+		   const uint64 *span_id, uint64 parent_id, uint64 query_id,
+		   TimestampTz start_span)
 {
-	TimestampTz start_span_time;
-
 	initialize_span_fields(span, type, trace_id, span_id, parent_id, query_id);
-
-	/* If no start span is provided, get the current one */
-	if (start_span == NULL)
-		start_span_time = GetCurrentTimestamp();
-	else
-		start_span_time = *start_span;
-
-	span->start = start_span_time;
+	span->start = start_span;
 }
 
 /*

--- a/src/pg_tracing_span.c
+++ b/src/pg_tracing_span.c
@@ -17,9 +17,12 @@
 /*
  * Initialize span fields
  */
-static void
-initialize_span_fields(Span * span, SpanType type, TraceId trace_id, const uint64 *span_id, uint64 parent_id, uint64 query_id)
+void
+begin_span(TraceId trace_id, Span * span, SpanType type,
+		   const uint64 *span_id, uint64 parent_id, uint64 query_id,
+		   TimestampTz start_span)
 {
+	span->start = start_span;
 	span->trace_id = trace_id;
 	span->type = type;
 
@@ -57,22 +60,9 @@ initialize_span_fields(Span * span, SpanType type, TraceId trace_id, const uint6
 	 */
 	if (type == SPAN_PLANNER || span->type == SPAN_PROCESS_UTILITY)
 	{
-		/* TODO Do we need to track wal for planner? */
 		span->node_counters.buffer_usage = pgBufferUsage;
 		span->node_counters.wal_usage = pgWalUsage;
 	}
-}
-
-/*
- * Initialize span and set span starting time.
- */
-void
-begin_span(TraceId trace_id, Span * span, SpanType type,
-		   const uint64 *span_id, uint64 parent_id, uint64 query_id,
-		   TimestampTz start_span)
-{
-	initialize_span_fields(span, type, trace_id, span_id, parent_id, query_id);
-	span->start = start_span;
 }
 
 /*

--- a/src/pg_tracing_sql_functions.c
+++ b/src/pg_tracing_sql_functions.c
@@ -208,7 +208,7 @@ pg_tracing_json_spans(PG_FUNCTION_ARGS)
 	StringInfoData str;
 	const char *qbuffer;
 	Size		qbuffer_size = 0;
-	pgTracingJsonContext ctx;
+	JsonContext ctx;
 
 	/* Don't trace this */
 	cleanup_tracing();

--- a/src/version_compat.h
+++ b/src/version_compat.h
@@ -30,6 +30,7 @@ extern void *guc_malloc(int elevel, size_t size);
 
 #if (PG_VERSION_NUM < 170000)
 
+#include "storage/backendid.h"
 /*
  * Compatibility with changes introduced in
  * https://www.postgresql.org/message-id/8171f1aa-496f-46a6-afc3-c46fe7a9b407@iki.fi


### PR DESCRIPTION
Introduce span_context structure to simplify passing all arguments (Query, PlannedStatement, query_text...) to span creation.