### PR TITLE
Add possibility to set tracecontext guc value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ endif
 REGRESSCHECKS += sample planstate planstate_bitmap planstate_hash \
 				 planstate_projectset planstate_subplans planstate_union \
 				 parallel subxact full_buffer \
-				 nested wal cleanup
+				 guc nested wal cleanup
 
 REGRESSCHECKS_OPTS = --no-locale --encoding=UTF8 --temp-config pg_tracing.conf
 

--- a/expected/guc.out
+++ b/expected/guc.out
@@ -1,0 +1,117 @@
+-- Test trace context propagation through GUCs
+SET pg_tracing.trace_context='dddbs=''postgres.db'',traceparent=''00-00000000000000000000000000000004-0000000000000004-01';
+SELECT 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+-- Test multiple statements
+SET pg_tracing.trace_context='dddbs=''postgres.db'',traceparent=''00-fffffffffffffffffffffffffffffff5-0000000000000005-01';
+SELECT 2;
+ ?column? 
+----------
+        2
+(1 row)
+
+SELECT 3;
+ ?column? 
+----------
+        3
+(1 row)
+
+-- Check results for GUC propagation with simple and multiple statements
+select trace_id, span_operation, parameters, lvl from peek_ordered_spans;
+             trace_id             | span_operation | parameters | lvl 
+----------------------------------+----------------+------------+-----
+ 00000000000000000000000000000004 | SELECT $1;     | $1 = 1     |   1
+ 00000000000000000000000000000004 | Planner        |            |   2
+ 00000000000000000000000000000004 | ExecutorRun    |            |   2
+ 00000000000000000000000000000004 | Result         |            |   3
+ fffffffffffffffffffffffffffffff5 | SELECT $1;     | $1 = 2     |   1
+ fffffffffffffffffffffffffffffff5 | Planner        |            |   2
+ fffffffffffffffffffffffffffffff5 | ExecutorRun    |            |   2
+ fffffffffffffffffffffffffffffff5 | Result         |            |   3
+ fffffffffffffffffffffffffffffff5 | SELECT $1;     | $1 = 3     |   1
+ fffffffffffffffffffffffffffffff5 | Planner        |            |   2
+ fffffffffffffffffffffffffffffff5 | ExecutorRun    |            |   2
+ fffffffffffffffffffffffffffffff5 | Result         |            |   3
+(12 rows)
+
+CALL clean_spans();
+-- Mix SQLCommenter and GUC propagation
+SET pg_tracing.trace_context='dddbs=''postgres.db'',traceparent=''00-fffffffffffffffffffffffffffffff6-0000000000000006-01';
+SELECT 2;
+ ?column? 
+----------
+        2
+(1 row)
+
+/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000001-0000000000000001-01'*/ SELECT 1, 1;
+ ?column? | ?column? 
+----------+----------
+        1 |        1
+(1 row)
+
+/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000009-0000000000000009-00'*/ SELECT 1, 2, 3;
+ ?column? | ?column? | ?column? 
+----------+----------+----------
+        1 |        2 |        3
+(1 row)
+
+SELECT 3;
+ ?column? 
+----------
+        3
+(1 row)
+
+-- Check mix SQLCommenter and GUC propagation
+select trace_id, span_operation, parameters, lvl from peek_ordered_spans;
+             trace_id             |   span_operation   |       parameters       | lvl 
+----------------------------------+--------------------+------------------------+-----
+ fffffffffffffffffffffffffffffff6 | SELECT $1;         | $1 = 2                 |   1
+ fffffffffffffffffffffffffffffff6 | Planner            |                        |   2
+ fffffffffffffffffffffffffffffff6 | ExecutorRun        |                        |   2
+ fffffffffffffffffffffffffffffff6 | Result             |                        |   3
+ fffffffffffffffffffffffffffffff6 | SELECT $1, $2;     | $1 = 1, $2 = 1         |   1
+ fffffffffffffffffffffffffffffff6 | Planner            |                        |   2
+ fffffffffffffffffffffffffffffff6 | ExecutorRun        |                        |   2
+ fffffffffffffffffffffffffffffff6 | Result             |                        |   3
+ fffffffffffffffffffffffffffffff6 | SELECT $1, $2, $3; | $1 = 1, $2 = 2, $3 = 3 |   1
+ fffffffffffffffffffffffffffffff6 | Planner            |                        |   2
+ fffffffffffffffffffffffffffffff6 | ExecutorRun        |                        |   2
+ fffffffffffffffffffffffffffffff6 | Result             |                        |   3
+ fffffffffffffffffffffffffffffff6 | SELECT $1;         | $1 = 3                 |   1
+ fffffffffffffffffffffffffffffff6 | Planner            |                        |   2
+ fffffffffffffffffffffffffffffff6 | ExecutorRun        |                        |   2
+ fffffffffffffffffffffffffffffff6 | Result             |                        |   3
+(16 rows)
+
+CALL clean_spans();
+-- Test statement after reset
+SET pg_tracing.trace_context TO default;
+SELECT 4;
+ ?column? 
+----------
+        4
+(1 row)
+
+-- Test no traceparent field
+SET pg_tracing.trace_context='dddbs=''postgres.db'',taceparent=''00-fffffffffffffffffffffffffffffff5-0000000000000005-01';
+ERROR:  invalid value for parameter "pg_tracing.trace_context": "dddbs='postgres.db',taceparent='00-fffffffffffffffffffffffffffffff5-0000000000000005-01"
+DETAIL:  Error parsing tracecontext: No traceparent field found
+-- Test incorrect trace id
+SET pg_tracing.trace_context='dddbs=''postgres.db'',traceparent=''00-ffffffffffffffffffffffffffffff5-0000000000000005-01';
+ERROR:  invalid value for parameter "pg_tracing.trace_context": "dddbs='postgres.db',traceparent='00-ffffffffffffffffffffffffffffff5-0000000000000005-01"
+DETAIL:  Error parsing tracecontext: Traceparent field doesn't have the correct size
+-- Test wrong format
+SET pg_tracing.trace_context='dddbs=''postgres.db'',traceparent=''00f-ffffffffffffffffffffffffffffff5-0000000000000005-01';
+ERROR:  invalid value for parameter "pg_tracing.trace_context": "dddbs='postgres.db',traceparent='00f-ffffffffffffffffffffffffffffff5-0000000000000005-01"
+DETAIL:  Error parsing tracecontext: Incorrect traceparent format
+-- GUC errors and no GUC tracecontext should not generate spans
+select count(*) = 0 from peek_ordered_spans;
+ ?column? 
+----------
+ t
+(1 row)
+

--- a/sql/guc.sql
+++ b/sql/guc.sql
@@ -1,0 +1,37 @@
+-- Test trace context propagation through GUCs
+SET pg_tracing.trace_context='dddbs=''postgres.db'',traceparent=''00-00000000000000000000000000000004-0000000000000004-01';
+SELECT 1;
+
+-- Test multiple statements
+SET pg_tracing.trace_context='dddbs=''postgres.db'',traceparent=''00-fffffffffffffffffffffffffffffff5-0000000000000005-01';
+SELECT 2;
+SELECT 3;
+
+-- Check results for GUC propagation with simple and multiple statements
+select trace_id, span_operation, parameters, lvl from peek_ordered_spans;
+CALL clean_spans();
+
+-- Mix SQLCommenter and GUC propagation
+SET pg_tracing.trace_context='dddbs=''postgres.db'',traceparent=''00-fffffffffffffffffffffffffffffff6-0000000000000006-01';
+SELECT 2;
+/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000001-0000000000000001-01'*/ SELECT 1, 1;
+/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000009-0000000000000009-00'*/ SELECT 1, 2, 3;
+SELECT 3;
+
+-- Check mix SQLCommenter and GUC propagation
+select trace_id, span_operation, parameters, lvl from peek_ordered_spans;
+CALL clean_spans();
+
+-- Test statement after reset
+SET pg_tracing.trace_context TO default;
+SELECT 4;
+
+-- Test no traceparent field
+SET pg_tracing.trace_context='dddbs=''postgres.db'',taceparent=''00-fffffffffffffffffffffffffffffff5-0000000000000005-01';
+-- Test incorrect trace id
+SET pg_tracing.trace_context='dddbs=''postgres.db'',traceparent=''00-ffffffffffffffffffffffffffffff5-0000000000000005-01';
+-- Test wrong format
+SET pg_tracing.trace_context='dddbs=''postgres.db'',traceparent=''00f-ffffffffffffffffffffffffffffff5-0000000000000005-01';
+
+-- GUC errors and no GUC tracecontext should not generate spans
+select count(*) = 0 from peek_ordered_spans;

--- a/src/pg_tracing.c
+++ b/src/pg_tracing.c
@@ -68,13 +68,13 @@ typedef enum
 	PG_TRACING_TRACK_NONE,		/* track no statements */
 	PG_TRACING_TRACK_TOP,		/* only top level statements */
 	PG_TRACING_TRACK_ALL		/* all statements, including nested ones */
-}			pgTracingTrackLevel;
+}			TrackingLevel;
 
 typedef enum
 {
 	PG_TRACING_KEEP_ON_FULL,	/* Keep existing buffers when full */
 	PG_TRACING_DROP_ON_FULL		/* Drop current buffers when full */
-}			pgTracingBufferMode;
+}			BufferMode;
 
 /*
  * Structure to store Query id filtering array of query id used for filtering
@@ -88,7 +88,7 @@ typedef struct QueryIdFilter
 /*
  * Structure to store per exec level informations
  */
-typedef struct pgTracingPerLevelInfos
+typedef struct PerLevelInfos
 {
 	uint64		executor_run_span_id;	/* executor run span id for this
 										 * level. Executor run is used as
@@ -96,7 +96,7 @@ typedef struct pgTracingPerLevelInfos
 										 * planstate */
 	TimestampTz executor_start;
 	TimestampTz executor_end;
-}			pgTracingPerLevelInfos;
+}			PerLevelInfos;
 
 /* GUC variables */
 static int	pg_tracing_max_span;	/* Maximum number of spans to store */
@@ -216,7 +216,7 @@ static Span commit_span;
 static uint64 current_query_id;
 
 static QueryIdFilter * query_id_filter = NULL;
-static pgTracingPerLevelInfos * per_level_infos = NULL;
+static PerLevelInfos * per_level_infos = NULL;
 
 /* Number of spans initially allocated at the start of a trace. */
 #define	INITIAL_ALLOCATED_SPANS 25
@@ -1152,7 +1152,7 @@ initialize_trace_level(void)
 		/* initial allocation */
 		allocated_nested_level = 1;
 		per_level_infos = palloc0(allocated_nested_level *
-								  sizeof(pgTracingPerLevelInfos));
+								  sizeof(PerLevelInfos));
 		current_trace_spans = palloc0(sizeof(pgTracingSpans) +
 									  INITIAL_ALLOCATED_SPANS * sizeof(Span));
 		current_trace_spans->max = INITIAL_ALLOCATED_SPANS;
@@ -1167,8 +1167,8 @@ initialize_trace_level(void)
 
 		allocated_nested_level++;
 		/* repalloc uses the pointer's memory context, no need to switch */
-		per_level_infos = repalloc0(per_level_infos, old_allocated_nested_level * sizeof(pgTracingPerLevelInfos),
-									allocated_nested_level * sizeof(pgTracingPerLevelInfos));
+		per_level_infos = repalloc0(per_level_infos, old_allocated_nested_level * sizeof(PerLevelInfos),
+									allocated_nested_level * sizeof(PerLevelInfos));
 	}
 }
 

--- a/src/pg_tracing.c
+++ b/src/pg_tracing.c
@@ -1026,7 +1026,7 @@ cleanup:
 /*
  * Reset traceparent fields
  */
-static void
+void
 reset_traceparent(Traceparent * traceparent)
 {
 	traceparent->sampled = 0;

--- a/src/pg_tracing.c
+++ b/src/pg_tracing.c
@@ -79,11 +79,11 @@ typedef enum
 /*
  * Structure to store Query id filtering array of query id used for filtering
  */
-typedef struct pgTracingQueryIdFilter
+typedef struct QueryIdFilter
 {
 	int			num_query_id;	/* number of query ids */
 	uint64		query_ids[FLEXIBLE_ARRAY_MEMBER];
-}			pgTracingQueryIdFilter;
+}			QueryIdFilter;
 
 /*
  * Structure to store per exec level informations
@@ -215,7 +215,7 @@ static Span commit_span;
  */
 static uint64 current_query_id;
 
-static pgTracingQueryIdFilter * query_id_filter = NULL;
+static QueryIdFilter * query_id_filter = NULL;
 static pgTracingPerLevelInfos * per_level_infos = NULL;
 
 /* Number of spans initially allocated at the start of a trace. */
@@ -586,8 +586,8 @@ check_filter_query_ids(char **newval, void **extra, GucSource source)
 	char	   *rawstring;
 	List	   *queryidlist;
 	ListCell   *l;
-	pgTracingQueryIdFilter *result;
-	pgTracingQueryIdFilter *query_ids;
+	QueryIdFilter *result;
+	QueryIdFilter *query_ids;
 	int			num_query_ids = 0;
 	size_t		size_query_id_filter;
 
@@ -609,9 +609,9 @@ check_filter_query_ids(char **newval, void **extra, GucSource source)
 		return false;
 	}
 
-	size_query_id_filter = sizeof(pgTracingQueryIdFilter) + list_length(queryidlist) * sizeof(uint64);
+	size_query_id_filter = sizeof(QueryIdFilter) + list_length(queryidlist) * sizeof(uint64);
 	/* Work on a palloced buffer */
-	query_ids = (pgTracingQueryIdFilter *) palloc(size_query_id_filter);
+	query_ids = (QueryIdFilter *) palloc(size_query_id_filter);
 
 	foreach(l, queryidlist)
 	{
@@ -633,7 +633,7 @@ check_filter_query_ids(char **newval, void **extra, GucSource source)
 	list_free(queryidlist);
 
 	/* Copy query id filter to a guc malloced result */
-	result = (pgTracingQueryIdFilter *) guc_malloc(LOG, size_query_id_filter);
+	result = (QueryIdFilter *) guc_malloc(LOG, size_query_id_filter);
 	if (result == NULL)
 		return false;
 	memcpy(result, query_ids, size_query_id_filter);
@@ -648,7 +648,7 @@ check_filter_query_ids(char **newval, void **extra, GucSource source)
 static void
 assign_filter_query_ids(const char *newval, void *extra)
 {
-	query_id_filter = (pgTracingQueryIdFilter *) extra;
+	query_id_filter = (QueryIdFilter *) extra;
 }
 
 /*

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -264,7 +264,7 @@ extern const char *plan_to_deparse_info(const planstateTraceContext * planstateT
 
 /* pg_tracing_parallel.c */
 extern void pg_tracing_shmem_parallel_startup(void);
-extern void add_parallel_context(const Traceparent *traceparent, uint64 parent_id);
+extern void add_parallel_context(const Traceparent * traceparent, uint64 parent_id);
 extern void remove_parallel_context(void);
 extern void fetch_parallel_context(Traceparent * traceparent);
 

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -337,6 +337,7 @@ extern void
 			drop_all_spans_locked(void);
 extern void
 			pg_tracing_shmem_startup(void);
+extern void reset_traceparent(Traceparent * traceparent);
 
 /* pg_tracing_json.c */
 extern void

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -56,6 +56,18 @@ typedef enum HookPhase
 }			HookPhase;
 
 /*
+ * Error code when parsing traceparent field
+ */
+typedef enum ParseTraceparentErr
+{
+	PARSE_OK = 0,
+	PARSE_INCORRECT_SIZE,
+	PARSE_NO_TRACEPARENT_FIELD,
+	PARSE_INCORRECT_TRACEPARENT_SIZE,
+	PARSE_INCORRECT_FORMAT,
+}			ParseTraceparentErr;
+
+/*
  * SpanType: Type of the span
  */
 typedef enum SpanType
@@ -291,7 +303,8 @@ extern const char *normalise_query_parameters(const JumbleState *jstate, const c
 											  int query_loc, int *query_len_p, char **param_str,
 											  int *param_len);
 extern void extract_trace_context_from_query(Traceparent * traceparent, const char *query);
-extern void parse_trace_context(Traceparent * traceparent, const char *trace_context_str, int trace_context_len);
+extern ParseTraceparentErr parse_trace_context(Traceparent * traceparent, const char *trace_context_str, int trace_context_len);
+extern char *parse_code_to_err(ParseTraceparentErr err);
 extern const char *normalise_query(const char *query, int query_loc, int *query_len_p);
 extern bool text_store_file(pgTracingSharedState * pg_tracing, const char *query,
 							int query_len, Size *query_offset);


### PR DESCRIPTION
Create a `pg_tracing.trace_context` guc parameter that allows to propagate tracecontext through GUC.

Example of usage:
```
SET pg_tracing.trace_context='dddbs=''postgres.db'',traceparent=''00-fffffffffffffffffffffffffffffff5-0000000000000005-01';
SELECT 2;
SET pg_tracing.trace_context TO default;
```

