### PR TITLE
Group spans by scope in json export

### DIFF
--- a/expected/cursor.out
+++ b/expected/cursor.out
@@ -143,11 +143,11 @@ SELECT span_type, span_operation, lvl from peek_ordered_spans where trace_id='00
  Utility query  | FETCH FORWARD 20 from c                             |   1
  ProcessUtility | ProcessUtility                                      |   2
  Select query   | DECLARE c CURSOR FOR SELECT * from pg_tracing_test; |   3
- Executor       | ExecutorRun                                         |   4
+ ExecutorRun    | ExecutorRun                                         |   4
  Utility query  | FETCH BACKWARD 10 from c                            |   1
  ProcessUtility | ProcessUtility                                      |   2
  Select query   | DECLARE c CURSOR FOR SELECT * from pg_tracing_test; |   3
- Executor       | ExecutorRun                                         |   4
+ ExecutorRun    | ExecutorRun                                         |   4
  Utility query  | CLOSE c;                                            |   1
  ProcessUtility | ProcessUtility                                      |   2
  Select query   | DECLARE c CURSOR FOR SELECT * from pg_tracing_test; |   3

--- a/expected/extended.out
+++ b/expected/extended.out
@@ -12,7 +12,7 @@ SELECT span_type, span_operation, parameters, lvl FROM peek_ordered_spans;
 --------------+----------------+--------------------+-----
  Select query | SELECT $1, $2  | $1 = '1', $2 = '2' |   1
  Planner      | Planner        |                    |   2
- Executor     | ExecutorRun    |                    |   2
+ ExecutorRun  | ExecutorRun    |                    |   2
  Result       | Result         |                    |   3
 (4 rows)
 
@@ -70,11 +70,11 @@ SELECT span_type, span_operation, parameters, lvl FROM peek_ordered_spans;
  ProcessUtility | ProcessUtility |                    |   2
  Select query   | SELECT $1      | $1 = '1'           |   1
  Planner        | Planner        |                    |   2
- Executor       | ExecutorRun    |                    |   2
+ ExecutorRun    | ExecutorRun    |                    |   2
  Result         | Result         |                    |   3
  Select query   | SELECT $1, $2  | $1 = '2', $2 = '3' |   1
  Planner        | Planner        |                    |   2
- Executor       | ExecutorRun    |                    |   2
+ ExecutorRun    | ExecutorRun    |                    |   2
  Result         | Result         |                    |   3
  Utility query  | COMMIT;        |                    |   1
  ProcessUtility | ProcessUtility |                    |   2
@@ -82,7 +82,7 @@ SELECT span_type, span_operation, parameters, lvl FROM peek_ordered_spans;
  ProcessUtility | ProcessUtility |                    |   2
  Select query   | SELECT $1      | $1 = '1'           |   1
  Planner        | Planner        |                    |   2
- Executor       | ExecutorRun    |                    |   2
+ ExecutorRun    | ExecutorRun    |                    |   2
  Result         | Result         |                    |   3
  Utility query  | COMMIT;        |                    |   1
  ProcessUtility | ProcessUtility |                    |   2
@@ -124,15 +124,15 @@ SELECT span_type, span_operation, parameters, lvl FROM peek_ordered_spans;
  ProcessUtility | ProcessUtility     |                        |   2
  Select query   | SELECT $1          | $1 = '1'               |   1
  Planner        | Planner            |                        |   2
- Executor       | ExecutorRun        |                        |   2
+ ExecutorRun    | ExecutorRun        |                        |   2
  Result         | Result             |                        |   3
  Select query   | SELECT $1, $2, $3; | $1 = 5, $2 = 6, $3 = 7 |   1
  Planner        | Planner            |                        |   2
- Executor       | ExecutorRun        |                        |   2
+ ExecutorRun    | ExecutorRun        |                        |   2
  Result         | Result             |                        |   3
  Select query   | SELECT $1, $2      | $1 = '2', $2 = '3'     |   1
  Planner        | Planner            |                        |   2
- Executor       | ExecutorRun        |                        |   2
+ ExecutorRun    | ExecutorRun        |                        |   2
  Result         | Result             |                        |   3
  Utility query  | COMMIT;            |                        |   1
  ProcessUtility | ProcessUtility     |                        |   2
@@ -153,7 +153,7 @@ SELECT span_type, span_operation, parameters, lvl FROM peek_ordered_spans;
  Select query | SELECT name AS "Column", pg_catalog.format_type(tp, tpm) AS "Type"+| $1 = '?column?', $2 = '23', $3 = -1 |   1
               | FROM (VALUES ($1, $2::pg_catalog.oid,$3)) s(name, tp, tpm)         |                                     | 
  Planner      | Planner                                                            |                                     |   2
- Executor     | ExecutorRun                                                        |                                     |   2
+ ExecutorRun  | ExecutorRun                                                        |                                     |   2
  Result       | Result                                                             |                                     |   3
 (5 rows)
 
@@ -188,15 +188,15 @@ SELECT span_type, span_operation, parameters, lvl FROM peek_ordered_spans WHERE 
  ProcessUtility | ProcessUtility    |                              |   2
  Select query   | SELECT $1         | $1 = '1'                     |   1
  Planner        | Planner           |                              |   2
- Executor       | ExecutorRun       |                              |   2
+ ExecutorRun    | ExecutorRun       |                              |   2
  Result         | Result            |                              |   3
  Select query   | SELECT $1, $2     | $1 = '1', $2 = '2'           |   1
  Planner        | Planner           |                              |   2
- Executor       | ExecutorRun       |                              |   2
+ ExecutorRun    | ExecutorRun       |                              |   2
  Result         | Result            |                              |   3
  Select query   | SELECT $1, $2, $3 | $1 = '1', $2 = '2', $3 = '3' |   1
  Planner        | Planner           |                              |   2
- Executor       | ExecutorRun       |                              |   2
+ ExecutorRun    | ExecutorRun       |                              |   2
  Result         | Result            |                              |   3
  Utility query  | COMMIT;           |                              |   1
  ProcessUtility | ProcessUtility    |                              |   2
@@ -228,15 +228,15 @@ SELECT span_type, span_operation, parameters, lvl FROM peek_ordered_spans WHERE 
 --------------+-------------------+------------------------------+-----
  Select query | SELECT $1         | $1 = '1'                     |   1
  Planner      | Planner           |                              |   2
- Executor     | ExecutorRun       |                              |   2
+ ExecutorRun  | ExecutorRun       |                              |   2
  Result       | Result            |                              |   3
  Select query | SELECT $1, $2     | $1 = '1', $2 = '2'           |   1
  Planner      | Planner           |                              |   2
- Executor     | ExecutorRun       |                              |   2
+ ExecutorRun  | ExecutorRun       |                              |   2
  Result       | Result            |                              |   3
  Select query | SELECT $1, $2, $3 | $1 = '1', $2 = '2', $3 = '3' |   1
  Planner      | Planner           |                              |   2
- Executor     | ExecutorRun       |                              |   2
+ ExecutorRun  | ExecutorRun       |                              |   2
  Result       | Result            |                              |   3
 (12 rows)
 
@@ -272,11 +272,11 @@ SELECT span_type, span_operation, parameters, lvl FROM peek_ordered_spans WHERE 
 --------------+-------------------+------------------------------+-----
  Select query | SELECT $1         | $1 = '1'                     |   1
  Planner      | Planner           |                              |   2
- Executor     | ExecutorRun       |                              |   2
+ ExecutorRun  | ExecutorRun       |                              |   2
  Result       | Result            |                              |   3
  Select query | SELECT $1, $2, $3 | $1 = '1', $2 = '2', $3 = '3' |   1
  Planner      | Planner           |                              |   2
- Executor     | ExecutorRun       |                              |   2
+ ExecutorRun  | ExecutorRun       |                              |   2
  Result       | Result            |                              |   3
 (8 rows)
 
@@ -296,7 +296,7 @@ SELECT span_type, span_operation, parameters, lvl FROM peek_ordered_spans WHERE 
  ProcessUtility | ProcessUtility |            |   2
  Select query   | SELECT $1      | $1 = '1'   |   1
  Planner        | Planner        |            |   2
- Executor       | ExecutorRun    |            |   2
+ ExecutorRun    | ExecutorRun    |            |   2
  Result         | Result         |            |   3
  Utility query  | COMMIT;        |            |   1
  ProcessUtility | ProcessUtility |            |   2

--- a/expected/insert.out
+++ b/expected/insert.out
@@ -19,7 +19,7 @@ SELECT span_type, span_operation from peek_ordered_spans where trace_id='0000000
 --------------+-------------------------------------------------------------------
  Insert query | INSERT INTO pg_tracing_test_table_with_constraint VALUES($1, $2);
  Planner      | Planner
- Executor     | ExecutorRun
+ ExecutorRun  | ExecutorRun
  Insert       | Insert on pg_tracing_test_table_with_constraint
  Result       | Result
  Commit       | Commit
@@ -34,7 +34,7 @@ SELECT span_type, span_operation, sql_error_code, lvl from peek_ordered_spans wh
 --------------+-------------------------------------------------------------------+----------------+-----
  Insert query | INSERT INTO pg_tracing_test_table_with_constraint VALUES($1, $2); | 23505          |   1
  Planner      | Planner                                                           | 00000          |   2
- Executor     | ExecutorRun                                                       | 23505          |   2
+ ExecutorRun  | ExecutorRun                                                       | 23505          |   2
  Insert       | Insert on pg_tracing_test_table_with_constraint                   | 23505          |   3
  Result       | Result                                                            | 23505          |   4
 (5 rows)

--- a/expected/nested.out
+++ b/expected/nested.out
@@ -46,7 +46,7 @@ SELECT span_id AS span_a_id,
 SELECT span_id AS span_d_id,
         get_epoch(span_start) as span_d_start,
         get_epoch(span_end) as span_d_end
-		from pg_tracing_peek_spans where parent_id=:'span_a_id' and span_type='Executor' and span_operation='ExecutorRun' \gset
+		from pg_tracing_peek_spans where parent_id=:'span_a_id' and span_operation='ExecutorRun' \gset
 SELECT span_id AS span_e_id,
         get_epoch(span_start) as span_e_start,
         get_epoch(span_end) as span_e_end
@@ -240,7 +240,7 @@ SELECT span_id AS span_a_id,
 SELECT span_id AS span_c_id,
         get_epoch(span_start) as span_c_start,
         get_epoch(span_end) as span_c_end
-		from pg_tracing_peek_spans where parent_id=:'span_a_id' and span_type='Executor' and span_operation='ExecutorRun' \gset
+		from pg_tracing_peek_spans where parent_id=:'span_a_id' and span_operation='ExecutorRun' \gset
 SELECT span_id AS span_d_id,
         get_epoch(span_start) as span_d_start,
         get_epoch(span_end) as span_d_end

--- a/expected/parallel.out
+++ b/expected/parallel.out
@@ -54,7 +54,7 @@ SELECT trace_id from pg_tracing_peek_spans group by trace_id;
 (3 rows)
 
 -- Check number of executor spans
-SELECT count(*) from pg_tracing_consume_spans where span_type='Executor';
+SELECT count(*) from pg_tracing_consume_spans where span_operation='ExecutorRun';
  count 
 -------
      7

--- a/expected/planstate.out
+++ b/expected/planstate.out
@@ -11,7 +11,7 @@ SELECT span_type, span_operation, deparse_info FROM peek_ordered_spans where tra
  Select query | SELECT s.relation_size + s.index_size as sum_size                                                                         +| 
               | FROM (SELECT pg_relation_size(C.oid) as relation_size, pg_indexes_size(C.oid) as index_size FROM pg_class C) as s limit $1 | 
  Planner      | Planner                                                                                                                    | 
- Executor     | ExecutorRun                                                                                                                | 
+ ExecutorRun  | ExecutorRun                                                                                                                | 
 (3 rows)
 
 -- Test with planstate_spans enabled
@@ -27,7 +27,7 @@ SELECT span_type, span_operation, deparse_info FROM peek_ordered_spans where tra
  Select query | SELECT s.relation_size + s.index_size as sum_size                                                                         +| 
               | FROM (SELECT pg_relation_size(C.oid) as relation_size, pg_indexes_size(C.oid) as index_size FROM pg_class C) as s limit $1 | 
  Planner      | Planner                                                                                                                    | 
- Executor     | ExecutorRun                                                                                                                | 
+ ExecutorRun  | ExecutorRun                                                                                                                | 
  Limit        | Limit                                                                                                                      | 
  SubqueryScan | SubqueryScan on s                                                                                                          | 
  SeqScan      | SeqScan on pg_class c                                                                                                      | 

--- a/expected/select.out
+++ b/expected/select.out
@@ -30,7 +30,7 @@ SELECT span_type, span_operation from pg_tracing_peek_spans where trace_id='0000
 --------------+----------------
  Select query | SELECT $1;
  Planner      | Planner
- Executor     | ExecutorRun
+ ExecutorRun  | ExecutorRun
  Result       | Result
 (4 rows)
 
@@ -70,7 +70,7 @@ SELECT span_type, span_operation, lvl FROM peek_ordered_spans where trace_id='00
 --------------+------------------------------------------+-----
  Select query | SELECT count(*) from current_database(); |   1
  Planner      | Planner                                  |   2
- Executor     | ExecutorRun                              |   2
+ ExecutorRun  | ExecutorRun                              |   2
  Aggregate    | Aggregate                                |   3
  FunctionScan | FunctionScan on current_database         |   4
 (5 rows)
@@ -95,7 +95,7 @@ SELECT span_type, span_operation, lvl FROM peek_ordered_spans where trace_id='00
  Select query | SELECT s.relation_size + s.index_size as relation_size                                                                    +|   1
               | FROM (SELECT pg_relation_size(C.oid) as relation_size, pg_indexes_size(C.oid) as index_size FROM pg_class C) as s limit $1 | 
  Planner      | Planner                                                                                                                    |   2
- Executor     | ExecutorRun                                                                                                                |   2
+ ExecutorRun  | ExecutorRun                                                                                                                |   2
  Limit        | Limit                                                                                                                      |   3
  SubqueryScan | SubqueryScan on s                                                                                                          |   4
  SeqScan      | SeqScan on pg_class c                                                                                                      |   5
@@ -111,7 +111,7 @@ SELECT span_type, span_operation, sql_error_code, lvl FROM peek_ordered_spans wh
 --------------+-----------------------------+----------------+-----
  Select query | select * from pg_sleep($1); | 57014          |   1
  Planner      | Planner                     | 00000          |   2
- Executor     | ExecutorRun                 | 57014          |   2
+ ExecutorRun  | ExecutorRun                 | 57014          |   2
  FunctionScan | FunctionScan on pg_sleep    | 57014          |   3
 (4 rows)
 
@@ -130,7 +130,7 @@ SELECT span_type, span_operation, sql_error_code, lvl FROM peek_ordered_spans wh
 --------------+----------------+----------------+-----
  Select query | select $1;     | 00000          |   1
  Planner      | Planner        | 00000          |   2
- Executor     | ExecutorRun    | 00000          |   2
+ ExecutorRun  | ExecutorRun    | 00000          |   2
  Result       | Result         | 00000          |   3
 (4 rows)
 
@@ -210,11 +210,11 @@ SELECT span_type, span_operation, parameters, lvl from peek_ordered_spans;
 --------------+----------------+----------------+-----
  Select query | SELECT $1;     | $1 = 1         |   1
  Planner      | Planner        |                |   2
- Executor     | ExecutorRun    |                |   2
+ ExecutorRun  | ExecutorRun    |                |   2
  Result       | Result         |                |   3
  Select query | SELECT $1, $2; | $1 = 1, $2 = 2 |   1
  Planner      | Planner        |                |   2
- Executor     | ExecutorRun    |                |   2
+ ExecutorRun  | ExecutorRun    |                |   2
  Result       | Result         |                |   3
 (8 rows)
 
@@ -270,7 +270,7 @@ SELECT span_type, span_operation, parameters, lvl from peek_ordered_spans;
  Commit         | Commit                                                                                                                                                                                                  |                                  |   1
  Select query   | SELECT lazy_function($1::int[]) FROM (VALUES ($2,$3)) as t;                                                                                                                                             | $1 = '{1,2,3,4}', $2 = 1, $3 = 2 |   1
  Planner        | Planner                                                                                                                                                                                                 |                                  |   2
- Executor       | ExecutorRun                                                                                                                                                                                             |                                  |   2
+ ExecutorRun    | ExecutorRun                                                                                                                                                                                             |                                  |   2
  ProjectSet     | ProjectSet                                                                                                                                                                                              |                                  |   3
  Result         | Result                                                                                                                                                                                                  |                                  |   4
  Select query   | select * from pg_catalog.generate_series(array_lower($1, $2), array_upper($1, $3), $4)                                                                                                                  | $1 = 1, $2 = 1, $3 = 1           |   4
@@ -290,15 +290,15 @@ SELECT span_type, span_operation, parameters, lvl from peek_ordered_spans;
 --------------+----------------------------------------------------------------------------------------+------------+-----
  Select query | SELECT information_schema._pg_truetypid(a, t) FROM pg_attribute a, pg_type t limit $1; | $1 = 1     |   1
  Planner      | Planner                                                                                |            |   2
- Executor     | ExecutorRun                                                                            |            |   2
+ ExecutorRun  | ExecutorRun                                                                            |            |   2
  Limit        | Limit                                                                                  |            |   3
  NestedLoop   | NestedLoop                                                                             |            |   4
  SeqScan      | SeqScan on pg_attribute a                                                              |            |   5
  Materialize  | Materialize                                                                            |            |   5
  SeqScan      | SeqScan on pg_type t                                                                   |            |   6
- Select query | Top                                                                                    |            |   3
+ Select query | Select query                                                                           |            |   3
  Planner      | Planner                                                                                |            |   4
- Executor     | ExecutorRun                                                                            |            |   4
+ ExecutorRun  | ExecutorRun                                                                            |            |   4
  Result       | Result                                                                                 |            |   5
 (12 rows)
 

--- a/expected/transaction.out
+++ b/expected/transaction.out
@@ -15,7 +15,7 @@ SELECT span_type, span_operation, lvl FROM peek_ordered_spans where trace_id='00
  ProcessUtility | ProcessUtility |   2
  Select query   | SELECT $1;     |   1
  Planner        | Planner        |   2
- Executor       | ExecutorRun    |   2
+ ExecutorRun    | ExecutorRun    |   2
  Result         | Result         |   3
  Utility query  | COMMIT;        |   1
  ProcessUtility | ProcessUtility |   2
@@ -43,7 +43,7 @@ SELECT span_type, span_operation, lvl FROM peek_ordered_spans where trace_id='00
 --------------+----------------+-----
  Select query | SELECT $1;     |   1
  Planner      | Planner        |   2
- Executor     | ExecutorRun    |   2
+ ExecutorRun  | ExecutorRun    |   2
  Result       | Result         |   3
 (4 rows)
 

--- a/expected/trigger.out
+++ b/expected/trigger.out
@@ -62,12 +62,12 @@ SELECT span_id AS span_c_id,
 SELECT span_id AS span_d_id,
         get_epoch(span_start) as span_d_start,
         get_epoch(span_end) as span_d_end
-		from pg_tracing_peek_spans where parent_id=:'span_b_id' and span_type='Executor' and span_operation='ExecutorRun' \gset
+		from pg_tracing_peek_spans where parent_id=:'span_b_id' and span_operation='ExecutorRun' \gset
 -- Executor Finish, first trigger
 SELECT span_id AS span_g_id,
         get_epoch(span_start) as span_g_start,
         get_epoch(span_end) as span_g_end
-		from pg_tracing_peek_spans where parent_id=:'span_b_id' and span_type='Executor' and span_operation='ExecutorFinish' \gset
+		from pg_tracing_peek_spans where parent_id=:'span_b_id' and span_operation='ExecutorFinish' \gset
 SELECT span_id AS span_i_id,
         get_epoch(span_start) as span_i_start,
         get_epoch(span_end) as span_i_end
@@ -79,7 +79,7 @@ SELECT span_id AS span_j_id,
 SELECT span_id AS span_k_id,
         get_epoch(span_start) as span_k_start,
         get_epoch(span_end) as span_k_end
-		from pg_tracing_peek_spans where parent_id=:'span_i_id' and span_type='Executor' and span_operation='ExecutorRun' \gset
+		from pg_tracing_peek_spans where parent_id=:'span_i_id' and span_operation='ExecutorRun' \gset
 -- Executor Finish, second trigger
 SELECT span_id AS span_n_id,
         get_epoch(span_start) as span_n_start,
@@ -88,7 +88,7 @@ SELECT span_id AS span_n_id,
 SELECT span_id AS span_o_id,
         get_epoch(span_start) as span_o_start,
         get_epoch(span_end) as span_o_end
-        from pg_tracing_peek_spans where parent_id=:'span_n_id' and span_type='Executor' and span_operation='ExecutorRun' \gset
+        from pg_tracing_peek_spans where parent_id=:'span_n_id' and span_operation='ExecutorRun' \gset
 -- Check that spans' start and end are within expection
 -- Planner
 SELECT :span_c_start >= :span_b_start as planner_starts_after_root_span;
@@ -132,25 +132,25 @@ SELECT :span_o_start >= :span_i_end  as second_trigger_starts_after_first,
 
 -- Check span_operation
 SELECT span_type, span_operation, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000001';
-  span_type   |                                                   span_operation                                                    | lvl 
---------------+---------------------------------------------------------------------------------------------------------------------+-----
- Insert query | INSERT INTO Employee VALUES($1,$2);                                                                                 |   1
- Planner      | Planner                                                                                                             |   2
- Executor     | ExecutorRun                                                                                                         |   2
- Insert       | Insert on employee                                                                                                  |   3
- Result       | Result                                                                                                              |   4
- Executor     | ExecutorFinish                                                                                                      |   2
- Insert query | INSERT INTO Employee_Audit (EmployeeId, LastName, EmpAdditionTime) VALUES(NEW.EmployeeId,NEW.LastName,current_date) |   3
- Planner      | Planner                                                                                                             |   4
- Executor     | ExecutorRun                                                                                                         |   4
- Insert       | Insert on employee_audit                                                                                            |   5
- Result       | Result                                                                                                              |   6
- Insert query | INSERT INTO Employee_Audit (EmployeeId, LastName, EmpAdditionTime) VALUES(NEW.EmployeeId,NEW.LastName,current_date) |   3
- Planner      | Planner                                                                                                             |   4
- Executor     | ExecutorRun                                                                                                         |   4
- Insert       | Insert on employee_audit                                                                                            |   5
- Result       | Result                                                                                                              |   6
- Commit       | Commit                                                                                                              |   1
+   span_type    |                                                   span_operation                                                    | lvl 
+----------------+---------------------------------------------------------------------------------------------------------------------+-----
+ Insert query   | INSERT INTO Employee VALUES($1,$2);                                                                                 |   1
+ Planner        | Planner                                                                                                             |   2
+ ExecutorRun    | ExecutorRun                                                                                                         |   2
+ Insert         | Insert on employee                                                                                                  |   3
+ Result         | Result                                                                                                              |   4
+ ExecutorFinish | ExecutorFinish                                                                                                      |   2
+ Insert query   | INSERT INTO Employee_Audit (EmployeeId, LastName, EmpAdditionTime) VALUES(NEW.EmployeeId,NEW.LastName,current_date) |   3
+ Planner        | Planner                                                                                                             |   4
+ ExecutorRun    | ExecutorRun                                                                                                         |   4
+ Insert         | Insert on employee_audit                                                                                            |   5
+ Result         | Result                                                                                                              |   6
+ Insert query   | INSERT INTO Employee_Audit (EmployeeId, LastName, EmpAdditionTime) VALUES(NEW.EmployeeId,NEW.LastName,current_date) |   3
+ Planner        | Planner                                                                                                             |   4
+ ExecutorRun    | ExecutorRun                                                                                                         |   4
+ Insert         | Insert on employee_audit                                                                                            |   5
+ Result         | Result                                                                                                              |   6
+ Commit         | Commit                                                                                                              |   1
 (17 rows)
 
 -- Check count of query_id
@@ -185,16 +185,16 @@ SELECT trace_id, span_type, span_operation, lvl from peek_ordered_spans where tr
 ----------------------------------+--------------+-----------------------------------------------------------------+-----
  00000000000000000000000000000001 | Insert query | INSERT INTO before_trigger_table SELECT generate_series($1,$2); |   1
  00000000000000000000000000000001 | Planner      | Planner                                                         |   2
- 00000000000000000000000000000001 | Executor     | ExecutorRun                                                     |   2
+ 00000000000000000000000000000001 | ExecutorRun  | ExecutorRun                                                     |   2
  00000000000000000000000000000001 | Insert       | Insert on before_trigger_table                                  |   3
  00000000000000000000000000000001 | ProjectSet   | ProjectSet                                                      |   4
  00000000000000000000000000000001 | Result       | Result                                                          |   5
  00000000000000000000000000000001 | Select query | SELECT $1                                                       |   5
  00000000000000000000000000000001 | Planner      | Planner                                                         |   6
- 00000000000000000000000000000001 | Executor     | ExecutorRun                                                     |   6
+ 00000000000000000000000000000001 | ExecutorRun  | ExecutorRun                                                     |   6
  00000000000000000000000000000001 | Result       | Result                                                          |   7
  00000000000000000000000000000001 | Select query | SELECT 'SELECT 1'                                               |   5
- 00000000000000000000000000000001 | Executor     | ExecutorRun                                                     |   6
+ 00000000000000000000000000000001 | ExecutorRun  | ExecutorRun                                                     |   6
  00000000000000000000000000000001 | Result       | Result                                                          |   7
  00000000000000000000000000000001 | Commit       | Commit                                                          |   1
 (14 rows)
@@ -206,15 +206,15 @@ SELECT trace_id, span_type, span_operation, lvl from peek_ordered_spans where tr
 ----------------------------------+--------------+---------------------------------------+-----
  00000000000000000000000000000002 | Update query | UPDATE before_trigger_table set a=$1; |   1
  00000000000000000000000000000002 | Planner      | Planner                               |   2
- 00000000000000000000000000000002 | Executor     | ExecutorRun                           |   2
+ 00000000000000000000000000000002 | ExecutorRun  | ExecutorRun                           |   2
  00000000000000000000000000000002 | Update       | Update on before_trigger_table        |   3
  00000000000000000000000000000002 | SeqScan      | SeqScan on before_trigger_table       |   4
  00000000000000000000000000000002 | Select query | SELECT $1                             |   3
  00000000000000000000000000000002 | Planner      | Planner                               |   4
- 00000000000000000000000000000002 | Executor     | ExecutorRun                           |   4
+ 00000000000000000000000000000002 | ExecutorRun  | ExecutorRun                           |   4
  00000000000000000000000000000002 | Result       | Result                                |   5
  00000000000000000000000000000002 | Select query | SELECT 'SELECT 1'                     |   3
- 00000000000000000000000000000002 | Executor     | ExecutorRun                           |   4
+ 00000000000000000000000000000002 | ExecutorRun  | ExecutorRun                           |   4
  00000000000000000000000000000002 | Result       | Result                                |   5
  00000000000000000000000000000002 | Commit       | Commit                                |   1
 (13 rows)
@@ -226,15 +226,15 @@ SELECT trace_id, span_type, span_operation, lvl from peek_ordered_spans where tr
 ----------------------------------+--------------+----------------------------------------------+-----
  00000000000000000000000000000003 | Delete query | DELETE FROM before_trigger_table where a=$1; |   1
  00000000000000000000000000000003 | Planner      | Planner                                      |   2
- 00000000000000000000000000000003 | Executor     | ExecutorRun                                  |   2
+ 00000000000000000000000000000003 | ExecutorRun  | ExecutorRun                                  |   2
  00000000000000000000000000000003 | Delete       | Delete on before_trigger_table               |   3
  00000000000000000000000000000003 | SeqScan      | SeqScan on before_trigger_table              |   4
  00000000000000000000000000000003 | Select query | SELECT $1                                    |   3
  00000000000000000000000000000003 | Planner      | Planner                                      |   4
- 00000000000000000000000000000003 | Executor     | ExecutorRun                                  |   4
+ 00000000000000000000000000000003 | ExecutorRun  | ExecutorRun                                  |   4
  00000000000000000000000000000003 | Result       | Result                                       |   5
  00000000000000000000000000000003 | Select query | SELECT 'SELECT 1'                            |   3
- 00000000000000000000000000000003 | Executor     | ExecutorRun                                  |   4
+ 00000000000000000000000000000003 | ExecutorRun  | ExecutorRun                                  |   4
  00000000000000000000000000000003 | Result       | Result                                       |   5
  00000000000000000000000000000003 | Commit       | Commit                                       |   1
 (13 rows)

--- a/expected/utility.out
+++ b/expected/utility.out
@@ -73,7 +73,7 @@ CREATE VIEW peek_ordered_spans AS
 -- Column type to convert json to record
 create type span_json as ("traceId" text, "parentSpanId" text, "spanId" text, name text, "startTimeUnixNano" text, "endTimeUnixNano" text, attributes jsonb, kind int);
 CREATE VIEW peek_json_spans AS
-SELECT * FROM jsonb_populate_recordset(null::span_json, (SELECT jsonb_path_query_first(pg_tracing_json_spans()::jsonb, '$.resourceSpans[0].scopeSpans[0].spans')));
+SELECT * FROM jsonb_populate_recordset(null::span_json, (SELECT jsonb_path_query_array(pg_tracing_json_spans()::jsonb, '$.resourceSpans[0].scopeSpans[*].spans[*]')));
 CREATE FUNCTION get_int_attribute(attributes jsonb, keyvalue text) returns bigint
     LANGUAGE SQL
     IMMUTABLE

--- a/expected/utility.out
+++ b/expected/utility.out
@@ -389,7 +389,7 @@ select trace_id, span_type, span_operation, sql_error_code, lvl from peek_ordere
 ----------------------------------+--------------+--------------------------------------------------------------+----------------+-----
  00000000000000000000000000000004 | Select query | select function_with_error($1::int[]);                       | 42P13          |   1
  00000000000000000000000000000004 | Planner      | Planner                                                      | 00000          |   2
- 00000000000000000000000000000004 | Executor     | ExecutorRun                                                  | 42P13          |   2
+ 00000000000000000000000000000004 | ExecutorRun  | ExecutorRun                                                  | 42P13          |   2
  00000000000000000000000000000004 | ProjectSet   | ProjectSet                                                   | 42P13          |   3
  00000000000000000000000000000004 | Result       | Result                                                       | 42P13          |   4
  00000000000000000000000000000004 | Select query | select s from pg_catalog.generate_series($1, $2, $3) as g(s) | 00000          |   4

--- a/expected/wal.out
+++ b/expected/wal.out
@@ -11,20 +11,20 @@ FROM peek_ordered_spans;
 ----------------------------------+--------------+------------------------------------------------------------------+-------------+-----------
  00000000000000000000000000000001 | Insert query | INSERT INTO pg_tracing_test VALUES(generate_series($1, $2), $3); | t           | t
  00000000000000000000000000000001 | Planner      | Planner                                                          | f           | f
- 00000000000000000000000000000001 | Executor     | ExecutorRun                                                      |             | 
+ 00000000000000000000000000000001 | ExecutorRun  | ExecutorRun                                                      |             | 
  00000000000000000000000000000001 | Insert       | Insert on pg_tracing_test                                        | t           | t
  00000000000000000000000000000001 | ProjectSet   | ProjectSet                                                       | f           | f
  00000000000000000000000000000001 | Result       | Result                                                           | f           | f
  00000000000000000000000000000001 | Commit       | Commit                                                           |             | 
  00000000000000000000000000000002 | Update query | UPDATE pg_tracing_test SET b = $1 WHERE a = $2;                  | t           | t
  00000000000000000000000000000002 | Planner      | Planner                                                          | f           | f
- 00000000000000000000000000000002 | Executor     | ExecutorRun                                                      |             | 
+ 00000000000000000000000000000002 | ExecutorRun  | ExecutorRun                                                      |             | 
  00000000000000000000000000000002 | Update       | Update on pg_tracing_test                                        | t           | t
  00000000000000000000000000000002 | IndexScan    | IndexScan using pg_tracing_index on pg_tracing_test              | f           | f
  00000000000000000000000000000002 | Commit       | Commit                                                           |             | 
  00000000000000000000000000000003 | Delete query | DELETE FROM pg_tracing_test WHERE a = $1;                        | t           | t
  00000000000000000000000000000003 | Planner      | Planner                                                          | f           | f
- 00000000000000000000000000000003 | Executor     | ExecutorRun                                                      |             | 
+ 00000000000000000000000000000003 | ExecutorRun  | ExecutorRun                                                      |             | 
  00000000000000000000000000000003 | Delete       | Delete on pg_tracing_test                                        | t           | t
  00000000000000000000000000000003 | IndexScan    | IndexScan using pg_tracing_index on pg_tracing_test              | t           | t
  00000000000000000000000000000003 | Commit       | Commit                                                           |             | 

--- a/sql/nested.sql
+++ b/sql/nested.sql
@@ -48,7 +48,7 @@ SELECT span_id AS span_a_id,
 SELECT span_id AS span_d_id,
         get_epoch(span_start) as span_d_start,
         get_epoch(span_end) as span_d_end
-		from pg_tracing_peek_spans where parent_id=:'span_a_id' and span_type='Executor' and span_operation='ExecutorRun' \gset
+		from pg_tracing_peek_spans where parent_id=:'span_a_id' and span_operation='ExecutorRun' \gset
 SELECT span_id AS span_e_id,
         get_epoch(span_start) as span_e_start,
         get_epoch(span_end) as span_e_end
@@ -174,7 +174,7 @@ SELECT span_id AS span_a_id,
 SELECT span_id AS span_c_id,
         get_epoch(span_start) as span_c_start,
         get_epoch(span_end) as span_c_end
-		from pg_tracing_peek_spans where parent_id=:'span_a_id' and span_type='Executor' and span_operation='ExecutorRun' \gset
+		from pg_tracing_peek_spans where parent_id=:'span_a_id' and span_operation='ExecutorRun' \gset
 SELECT span_id AS span_d_id,
         get_epoch(span_start) as span_d_start,
         get_epoch(span_end) as span_d_end

--- a/sql/parallel.sql
+++ b/sql/parallel.sql
@@ -27,7 +27,7 @@ SELECT trace_id, span_type, span_operation from pg_tracing_peek_spans where span
 SELECT trace_id from pg_tracing_peek_spans group by trace_id;
 
 -- Check number of executor spans
-SELECT count(*) from pg_tracing_consume_spans where span_type='Executor';
+SELECT count(*) from pg_tracing_consume_spans where span_operation='ExecutorRun';
 
 -- Cleanup
 CALL clean_spans();

--- a/sql/trigger.sql
+++ b/sql/trigger.sql
@@ -71,13 +71,13 @@ SELECT span_id AS span_c_id,
 SELECT span_id AS span_d_id,
         get_epoch(span_start) as span_d_start,
         get_epoch(span_end) as span_d_end
-		from pg_tracing_peek_spans where parent_id=:'span_b_id' and span_type='Executor' and span_operation='ExecutorRun' \gset
+		from pg_tracing_peek_spans where parent_id=:'span_b_id' and span_operation='ExecutorRun' \gset
 
 -- Executor Finish, first trigger
 SELECT span_id AS span_g_id,
         get_epoch(span_start) as span_g_start,
         get_epoch(span_end) as span_g_end
-		from pg_tracing_peek_spans where parent_id=:'span_b_id' and span_type='Executor' and span_operation='ExecutorFinish' \gset
+		from pg_tracing_peek_spans where parent_id=:'span_b_id' and span_operation='ExecutorFinish' \gset
 SELECT span_id AS span_i_id,
         get_epoch(span_start) as span_i_start,
         get_epoch(span_end) as span_i_end
@@ -89,7 +89,7 @@ SELECT span_id AS span_j_id,
 SELECT span_id AS span_k_id,
         get_epoch(span_start) as span_k_start,
         get_epoch(span_end) as span_k_end
-		from pg_tracing_peek_spans where parent_id=:'span_i_id' and span_type='Executor' and span_operation='ExecutorRun' \gset
+		from pg_tracing_peek_spans where parent_id=:'span_i_id' and span_operation='ExecutorRun' \gset
 
 -- Executor Finish, second trigger
 SELECT span_id AS span_n_id,
@@ -99,7 +99,7 @@ SELECT span_id AS span_n_id,
 SELECT span_id AS span_o_id,
         get_epoch(span_start) as span_o_start,
         get_epoch(span_end) as span_o_end
-        from pg_tracing_peek_spans where parent_id=:'span_n_id' and span_type='Executor' and span_operation='ExecutorRun' \gset
+        from pg_tracing_peek_spans where parent_id=:'span_n_id' and span_operation='ExecutorRun' \gset
 
 -- Check that spans' start and end are within expection
 -- Planner

--- a/sql/utility.sql
+++ b/sql/utility.sql
@@ -83,7 +83,7 @@ CREATE VIEW peek_ordered_spans AS
 -- Column type to convert json to record
 create type span_json as ("traceId" text, "parentSpanId" text, "spanId" text, name text, "startTimeUnixNano" text, "endTimeUnixNano" text, attributes jsonb, kind int);
 CREATE VIEW peek_json_spans AS
-SELECT * FROM jsonb_populate_recordset(null::span_json, (SELECT jsonb_path_query_first(pg_tracing_json_spans()::jsonb, '$.resourceSpans[0].scopeSpans[0].spans')));
+SELECT * FROM jsonb_populate_recordset(null::span_json, (SELECT jsonb_path_query_array(pg_tracing_json_spans()::jsonb, '$.resourceSpans[0].scopeSpans[*].spans[*]')));
 
 CREATE FUNCTION get_int_attribute(attributes jsonb, keyvalue text) returns bigint
     LANGUAGE SQL

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -320,6 +320,8 @@ typedef struct JsonContext
 	StringInfo	str;
 	const char *qbuffer;
 	Size		qbuffer_size;
+	int			span_type_count[NUM_SPAN_TYPE];
+	const		Span **span_type_to_spans[NUM_SPAN_TYPE];
 }			JsonContext;
 
 typedef struct SpanContext
@@ -420,7 +422,9 @@ extern void reset_traceparent(Traceparent * traceparent);
 
 /* pg_tracing_json.c */
 extern void
-			marshal_spans_to_json(const JsonContext * json_ctx, const pgTracingSpans * spans);
+			marshal_spans_to_json(JsonContext * json_ctx);
+extern void
+			build_json_context(JsonContext * json_ctx, const char *qbuffer, Size qbuffer_size, const pgTracingSpans * pgTracingSpans);
 
 /* pg_tracing_otel.c */
 extern void

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -82,8 +82,72 @@ typedef enum SpanType
 
 	/* Represents a node execution, generated from planstate */
 	SPAN_NODE,
+	SPAN_NODE_RESULT,
+	SPAN_NODE_PROJECT_SET,
+
+	/* Modify table */
+	SPAN_NODE_INSERT,
+	SPAN_NODE_UPDATE,
+	SPAN_NODE_DELETE,
+	SPAN_NODE_MERGE,
+
+	SPAN_NODE_APPEND,
+	SPAN_NODE_MERGE_APPEND,
+	SPAN_NODE_RECURSIVE_UNION,
+	SPAN_NODE_BITMAP_AND,
+	SPAN_NODE_BITMAP_OR,
+	SPAN_NODE_NESTLOOP,
+	SPAN_NODE_MERGE_JOIN,
+	SPAN_NODE_HASH_JOIN,
+	SPAN_NODE_SEQ_SCAN,
+	SPAN_NODE_SAMPLE_SCAN,
+	SPAN_NODE_GATHER,
+	SPAN_NODE_GATHER_MERGE,
+	SPAN_NODE_INDEX_SCAN,
+	SPAN_NODE_INDEX_ONLY_SCAN,
+	SPAN_NODE_BITMAP_INDEX_SCAN,
+	SPAN_NODE_BITMAP_HEAP_SCAN,
+	SPAN_NODE_TID_SCAN,
+	SPAN_NODE_TID_RANGE_SCAN,
+	SPAN_NODE_SUBQUERY_SCAN,
+	SPAN_NODE_FUNCTION_SCAN,
+	SPAN_NODE_TABLEFUNC_SCAN,
+	SPAN_NODE_VALUES_SCAN,
+	SPAN_NODE_CTE_SCAN,
+	SPAN_NODE_NAMED_TUPLE_STORE_SCAN,
+	SPAN_NODE_WORKTABLE_SCAN,
+
+	SPAN_NODE_FOREIGN_SCAN,
+	SPAN_NODE_FOREIGN_INSERT,
+	SPAN_NODE_FOREIGN_UPDATE,
+	SPAN_NODE_FOREIGN_DELETE,
+
+	SPAN_NODE_CUSTOM_SCAN,
+	SPAN_NODE_MATERIALIZE,
+	SPAN_NODE_MEMOIZE,
+	SPAN_NODE_SORT,
+	SPAN_NODE_INCREMENTAL_SORT,
+	SPAN_NODE_GROUP,
+
+	SPAN_NODE_AGGREGATE,
+	SPAN_NODE_GROUP_AGGREGATE,
+	SPAN_NODE_HASH_AGGREGATE,
+	SPAN_NODE_MIXED_AGGREGATE,
+
+	SPAN_NODE_WINDOW_AGG,
+	SPAN_NODE_UNIQUE,
+
+	SPAN_NODE_SETOP,
+	SPAN_NODE_SETOP_HASHED,
+
+	SPAN_NODE_LOCK_ROWS,
+	SPAN_NODE_LIMIT,
+	SPAN_NODE_HASH,
+
 	SPAN_NODE_INIT_PLAN,
 	SPAN_NODE_SUBPLAN,
+
+	SPAN_NODE_UNKNOWN,
 
 	/* Top Span types. They are created from the query cmdType */
 	SPAN_TOP_SELECT,
@@ -94,6 +158,8 @@ typedef enum SpanType
 	SPAN_TOP_UTILITY,
 	SPAN_TOP_NOTHING,
 	SPAN_TOP_UNKNOWN,
+
+	NUM_SPAN_TYPE,				/* Must be last! */
 }			SpanType;
 
 
@@ -144,7 +210,6 @@ typedef struct Span
 	 * the position of NULL terminated strings in the file. Set to -1 if
 	 * unused.
 	 */
-	Size		node_type_offset;	/* name of the node type */
 	Size		operation_name_offset;	/* operation represented by the span */
 	Size		parameter_offset;	/* query parameters values */
 	Size		deparse_info_offset;	/* info from deparsed plan */
@@ -270,8 +335,8 @@ typedef struct SpanContext
 }			SpanContext;
 
 /* pg_tracing_explain.c */
-extern const char *plan_to_node_type(const Plan *plan);
-extern const char *plan_to_operation(const planstateTraceContext * planstateTraceContext, const PlanState *planstate, const char *spanName);
+extern SpanType plan_to_span_type(const Plan *plan);
+extern const char *plan_to_operation(const planstateTraceContext * planstateTraceContext, const PlanState *planstate, SpanType span_type);
 extern const char *plan_to_deparse_info(const planstateTraceContext * planstateTraceContext, const PlanState *planstate);
 
 /* pg_tracing_parallel.c */
@@ -316,10 +381,11 @@ extern void begin_span(TraceId trace_id, Span * span, SpanType type,
 					   TimestampTz start_span);
 extern void end_span(Span * span, const TimestampTz *end_time);
 extern void reset_span(Span * span);
-extern const char *get_span_type(const Span * span, const char *qbuffer, Size qbuffer_size);
+extern const char *get_span_type(const Span * span);
 extern const char *get_operation_name(const Span * span, const char *qbuffer, Size qbuffer_size);
 extern void adjust_file_offset(Span * span, Size file_position);
 extern bool traceid_zero(TraceId trace_id);
+extern const char *span_type_to_str(SpanType span_type);
 
 
 /* pg_tracing_sql_functions.c */

--- a/src/pg_tracing_sql_functions.c
+++ b/src/pg_tracing_sql_functions.c
@@ -150,7 +150,7 @@ add_result_span(ReturnSetInfo *rsinfo, Span * span,
 	char		parent_id[17];
 	char		span_id[17];
 
-	span_type = get_span_type(span, qbuffer, qbuffer_size);
+	span_type = span_type_to_str(span->type);
 	operation_name = get_operation_name(span, qbuffer, qbuffer_size);
 	sql_error_code = unpack_sql_state(span->sql_error_code);
 


### PR DESCRIPTION
Group spans by span_type (Planner, Select Query, SeqScan...) by using scopeSpans from OTLP/json.