### PR TITLE
Optimise text stored in query text

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,9 +45,8 @@ TAP_TESTS = 1
 include $(PGXS)
 
 regresscheck_noinstall:
-	$(pg_regress_check) \
-        $(REGRESSCHECKS_OPTS) \
-        $(REGRESSCHECKS)
+	$(pg_regress_check) $(REGRESSCHECKS_OPTS) $(REGRESSCHECKS) || \
+	(cat regression.diffs && exit 1)
 
 regresscheck: install regresscheck_noinstall
 
@@ -78,4 +77,4 @@ run-test: build-test-pg$(PG_VERSION)
 	docker run					                \
 		--name $(TEST_CONTAINER_NAME) --rm		\
 		$(TEST_CONTAINER_NAME):pg$(PG_VERSION)	\
-		bash -c "PG_VERSION=$(PG_VERSION) make regresscheck_noinstall || (cat /usr/src/pg_tracing/regression.diffs && exit 1); make installcheck"
+		bash -c "PG_VERSION=$(PG_VERSION) make regresscheck_noinstall && make installcheck"

--- a/expected/extended.out
+++ b/expected/extended.out
@@ -8,12 +8,12 @@ SELECT $1, $2 \bind 1 2 \g
 (1 row)
 
 SELECT span_type, span_operation, parameters, lvl FROM peek_ordered_spans;
-  span_type   | span_operation |     parameters     | lvl 
---------------+----------------+--------------------+-----
- Select query | SELECT $1, $2  | $1 = '1', $2 = '2' |   1
- Planner      | Planner        |                    |   2
- ExecutorRun  | ExecutorRun    |                    |   2
- Result       | Result         |                    |   3
+  span_type   | span_operation | parameters | lvl 
+--------------+----------------+------------+-----
+ Select query | SELECT $1, $2  | {1,2}      |   1
+ Planner      | Planner        |            |   2
+ ExecutorRun  | ExecutorRun    |            |   2
+ Result       | Result         |            |   3
 (4 rows)
 
 CALL clean_spans();
@@ -64,28 +64,28 @@ SELECT count(distinct(trace_id)) = 1 FROM pg_tracing_peek_spans;
 (1 row)
 
 SELECT span_type, span_operation, parameters, lvl FROM peek_ordered_spans;
-   span_type    | span_operation |     parameters     | lvl 
-----------------+----------------+--------------------+-----
- Utility query  | BEGIN;         |                    |   1
- ProcessUtility | ProcessUtility |                    |   2
- Select query   | SELECT $1      | $1 = '1'           |   1
- Planner        | Planner        |                    |   2
- ExecutorRun    | ExecutorRun    |                    |   2
- Result         | Result         |                    |   3
- Select query   | SELECT $1, $2  | $1 = '2', $2 = '3' |   1
- Planner        | Planner        |                    |   2
- ExecutorRun    | ExecutorRun    |                    |   2
- Result         | Result         |                    |   3
- Utility query  | COMMIT;        |                    |   1
- ProcessUtility | ProcessUtility |                    |   2
- Utility query  | BEGIN          |                    |   1
- ProcessUtility | ProcessUtility |                    |   2
- Select query   | SELECT $1      | $1 = '1'           |   1
- Planner        | Planner        |                    |   2
- ExecutorRun    | ExecutorRun    |                    |   2
- Result         | Result         |                    |   3
- Utility query  | COMMIT;        |                    |   1
- ProcessUtility | ProcessUtility |                    |   2
+   span_type    | span_operation | parameters | lvl 
+----------------+----------------+------------+-----
+ Utility query  | BEGIN;         |            |   1
+ ProcessUtility | ProcessUtility |            |   2
+ Select query   | SELECT $1      | {1}        |   1
+ Planner        | Planner        |            |   2
+ ExecutorRun    | ExecutorRun    |            |   2
+ Result         | Result         |            |   3
+ Select query   | SELECT $1, $2  | {2,3}      |   1
+ Planner        | Planner        |            |   2
+ ExecutorRun    | ExecutorRun    |            |   2
+ Result         | Result         |            |   3
+ Utility query  | COMMIT;        |            |   1
+ ProcessUtility | ProcessUtility |            |   2
+ Utility query  | BEGIN          |            |   1
+ ProcessUtility | ProcessUtility |            |   2
+ Select query   | SELECT $1      | {1}        |   1
+ Planner        | Planner        |            |   2
+ ExecutorRun    | ExecutorRun    |            |   2
+ Result         | Result         |            |   3
+ Utility query  | COMMIT;        |            |   1
+ ProcessUtility | ProcessUtility |            |   2
 (20 rows)
 
 CALL clean_spans();
@@ -118,24 +118,24 @@ SELECT count(distinct(trace_id)) = 1 FROM pg_tracing_peek_spans;
 (1 row)
 
 SELECT span_type, span_operation, parameters, lvl FROM peek_ordered_spans;
-   span_type    |   span_operation   |       parameters       | lvl 
-----------------+--------------------+------------------------+-----
- Utility query  | BEGIN;             |                        |   1
- ProcessUtility | ProcessUtility     |                        |   2
- Select query   | SELECT $1          | $1 = '1'               |   1
- Planner        | Planner            |                        |   2
- ExecutorRun    | ExecutorRun        |                        |   2
- Result         | Result             |                        |   3
- Select query   | SELECT $1, $2, $3; | $1 = 5, $2 = 6, $3 = 7 |   1
- Planner        | Planner            |                        |   2
- ExecutorRun    | ExecutorRun        |                        |   2
- Result         | Result             |                        |   3
- Select query   | SELECT $1, $2      | $1 = '2', $2 = '3'     |   1
- Planner        | Planner            |                        |   2
- ExecutorRun    | ExecutorRun        |                        |   2
- Result         | Result             |                        |   3
- Utility query  | COMMIT;            |                        |   1
- ProcessUtility | ProcessUtility     |                        |   2
+   span_type    |   span_operation   | parameters | lvl 
+----------------+--------------------+------------+-----
+ Utility query  | BEGIN;             |            |   1
+ ProcessUtility | ProcessUtility     |            |   2
+ Select query   | SELECT $1          | {1}        |   1
+ Planner        | Planner            |            |   2
+ ExecutorRun    | ExecutorRun        |            |   2
+ Result         | Result             |            |   3
+ Select query   | SELECT $1, $2, $3; | {5,6,7}    |   1
+ Planner        | Planner            |            |   2
+ ExecutorRun    | ExecutorRun        |            |   2
+ Result         | Result             |            |   3
+ Select query   | SELECT $1, $2      | {2,3}      |   1
+ Planner        | Planner            |            |   2
+ ExecutorRun    | ExecutorRun        |            |   2
+ Result         | Result             |            |   3
+ Utility query  | COMMIT;            |            |   1
+ ProcessUtility | ProcessUtility     |            |   2
 (16 rows)
 
 CALL clean_spans();
@@ -147,14 +147,14 @@ SELECT 1 \gdesc
 (1 row)
 
 SELECT span_type, span_operation, parameters, lvl FROM peek_ordered_spans;
-  span_type   |                           span_operation                           |             parameters              | lvl 
---------------+--------------------------------------------------------------------+-------------------------------------+-----
- Select query | SELECT $1                                                          | $1 = 1                              |   1
- Select query | SELECT name AS "Column", pg_catalog.format_type(tp, tpm) AS "Type"+| $1 = '?column?', $2 = '23', $3 = -1 |   1
-              | FROM (VALUES ($1, $2::pg_catalog.oid,$3)) s(name, tp, tpm)         |                                     | 
- Planner      | Planner                                                            |                                     |   2
- ExecutorRun  | ExecutorRun                                                        |                                     |   2
- Result       | Result                                                             |                                     |   3
+  span_type   |                           span_operation                           |      parameters      | lvl 
+--------------+--------------------------------------------------------------------+----------------------+-----
+ Select query | SELECT $1                                                          | {1}                  |   1
+ Select query | SELECT name AS "Column", pg_catalog.format_type(tp, tpm) AS "Type"+| {'?column?','23',-1} |   1
+              | FROM (VALUES ($1, $2::pg_catalog.oid,$3)) s(name, tp, tpm)         |                      | 
+ Planner      | Planner                                                            |                      |   2
+ ExecutorRun  | ExecutorRun                                                        |                      |   2
+ Result       | Result                                                             |                      |   3
 (5 rows)
 
 CALL clean_spans();
@@ -182,24 +182,24 @@ SELECT $1, $2, $3 \bind 1 2 3 \g
 
 COMMIT;
 SELECT span_type, span_operation, parameters, lvl FROM peek_ordered_spans WHERE trace_id='00000000000000000000000000000001';
-   span_type    |  span_operation   |          parameters          | lvl 
-----------------+-------------------+------------------------------+-----
- Utility query  | BEGIN;            |                              |   1
- ProcessUtility | ProcessUtility    |                              |   2
- Select query   | SELECT $1         | $1 = '1'                     |   1
- Planner        | Planner           |                              |   2
- ExecutorRun    | ExecutorRun       |                              |   2
- Result         | Result            |                              |   3
- Select query   | SELECT $1, $2     | $1 = '1', $2 = '2'           |   1
- Planner        | Planner           |                              |   2
- ExecutorRun    | ExecutorRun       |                              |   2
- Result         | Result            |                              |   3
- Select query   | SELECT $1, $2, $3 | $1 = '1', $2 = '2', $3 = '3' |   1
- Planner        | Planner           |                              |   2
- ExecutorRun    | ExecutorRun       |                              |   2
- Result         | Result            |                              |   3
- Utility query  | COMMIT;           |                              |   1
- ProcessUtility | ProcessUtility    |                              |   2
+   span_type    |  span_operation   | parameters | lvl 
+----------------+-------------------+------------+-----
+ Utility query  | BEGIN;            |            |   1
+ ProcessUtility | ProcessUtility    |            |   2
+ Select query   | SELECT $1         | {1}        |   1
+ Planner        | Planner           |            |   2
+ ExecutorRun    | ExecutorRun       |            |   2
+ Result         | Result            |            |   3
+ Select query   | SELECT $1, $2     | {1,2}      |   1
+ Planner        | Planner           |            |   2
+ ExecutorRun    | ExecutorRun       |            |   2
+ Result         | Result            |            |   3
+ Select query   | SELECT $1, $2, $3 | {1,2,3}    |   1
+ Planner        | Planner           |            |   2
+ ExecutorRun    | ExecutorRun       |            |   2
+ Result         | Result            |            |   3
+ Utility query  | COMMIT;           |            |   1
+ ProcessUtility | ProcessUtility    |            |   2
 (16 rows)
 
 -- Test tracing only individual statements with extended protocol
@@ -224,20 +224,20 @@ BEGIN;
 
 COMMIT;
 SELECT span_type, span_operation, parameters, lvl FROM peek_ordered_spans WHERE trace_id='00000000000000000000000000000002';
-  span_type   |  span_operation   |          parameters          | lvl 
---------------+-------------------+------------------------------+-----
- Select query | SELECT $1         | $1 = '1'                     |   1
- Planner      | Planner           |                              |   2
- ExecutorRun  | ExecutorRun       |                              |   2
- Result       | Result            |                              |   3
- Select query | SELECT $1, $2     | $1 = '1', $2 = '2'           |   1
- Planner      | Planner           |                              |   2
- ExecutorRun  | ExecutorRun       |                              |   2
- Result       | Result            |                              |   3
- Select query | SELECT $1, $2, $3 | $1 = '1', $2 = '2', $3 = '3' |   1
- Planner      | Planner           |                              |   2
- ExecutorRun  | ExecutorRun       |                              |   2
- Result       | Result            |                              |   3
+  span_type   |  span_operation   | parameters | lvl 
+--------------+-------------------+------------+-----
+ Select query | SELECT $1         | {1}        |   1
+ Planner      | Planner           |            |   2
+ ExecutorRun  | ExecutorRun       |            |   2
+ Result       | Result            |            |   3
+ Select query | SELECT $1, $2     | {1,2}      |   1
+ Planner      | Planner           |            |   2
+ ExecutorRun  | ExecutorRun       |            |   2
+ Result       | Result            |            |   3
+ Select query | SELECT $1, $2, $3 | {1,2,3}    |   1
+ Planner      | Planner           |            |   2
+ ExecutorRun  | ExecutorRun       |            |   2
+ Result       | Result            |            |   3
 (12 rows)
 
 -- Test tracing only subset of individual statements with extended protocol
@@ -268,16 +268,16 @@ SELECT $1 \bind 1 \g
 
 COMMIT;
 SELECT span_type, span_operation, parameters, lvl FROM peek_ordered_spans WHERE trace_id='00000000000000000000000000000003';
-  span_type   |  span_operation   |          parameters          | lvl 
---------------+-------------------+------------------------------+-----
- Select query | SELECT $1         | $1 = '1'                     |   1
- Planner      | Planner           |                              |   2
- ExecutorRun  | ExecutorRun       |                              |   2
- Result       | Result            |                              |   3
- Select query | SELECT $1, $2, $3 | $1 = '1', $2 = '2', $3 = '3' |   1
- Planner      | Planner           |                              |   2
- ExecutorRun  | ExecutorRun       |                              |   2
- Result       | Result            |                              |   3
+  span_type   |  span_operation   | parameters | lvl 
+--------------+-------------------+------------+-----
+ Select query | SELECT $1         | {1}        |   1
+ Planner      | Planner           |            |   2
+ ExecutorRun  | ExecutorRun       |            |   2
+ Result       | Result            |            |   3
+ Select query | SELECT $1, $2, $3 | {1,2,3}    |   1
+ Planner      | Planner           |            |   2
+ ExecutorRun  | ExecutorRun       |            |   2
+ Result       | Result            |            |   3
 (8 rows)
 
 -- Test tracing the whole transaction with extended protocol with BEGIN sent through extended protocol
@@ -294,7 +294,7 @@ SELECT span_type, span_operation, parameters, lvl FROM peek_ordered_spans WHERE 
 ----------------+----------------+------------+-----
  Utility query  | BEGIN          |            |   1
  ProcessUtility | ProcessUtility |            |   2
- Select query   | SELECT $1      | $1 = '1'   |   1
+ Select query   | SELECT $1      | {1}        |   1
  Planner        | Planner        |            |   2
  ExecutorRun    | ExecutorRun    |            |   2
  Result         | Result         |            |   3

--- a/expected/guc.out
+++ b/expected/guc.out
@@ -24,15 +24,15 @@ SELECT 3;
 select trace_id, span_operation, parameters, lvl from peek_ordered_spans;
              trace_id             | span_operation | parameters | lvl 
 ----------------------------------+----------------+------------+-----
- 00000000000000000000000000000004 | SELECT $1;     | $1 = 1     |   1
+ 00000000000000000000000000000004 | SELECT $1;     | {1}        |   1
  00000000000000000000000000000004 | Planner        |            |   2
  00000000000000000000000000000004 | ExecutorRun    |            |   2
  00000000000000000000000000000004 | Result         |            |   3
- fffffffffffffffffffffffffffffff5 | SELECT $1;     | $1 = 2     |   1
+ fffffffffffffffffffffffffffffff5 | SELECT $1;     | {2}        |   1
  fffffffffffffffffffffffffffffff5 | Planner        |            |   2
  fffffffffffffffffffffffffffffff5 | ExecutorRun    |            |   2
  fffffffffffffffffffffffffffffff5 | Result         |            |   3
- fffffffffffffffffffffffffffffff5 | SELECT $1;     | $1 = 3     |   1
+ fffffffffffffffffffffffffffffff5 | SELECT $1;     | {3}        |   1
  fffffffffffffffffffffffffffffff5 | Planner        |            |   2
  fffffffffffffffffffffffffffffff5 | ExecutorRun    |            |   2
  fffffffffffffffffffffffffffffff5 | Result         |            |   3
@@ -67,24 +67,24 @@ SELECT 3;
 
 -- Check mix SQLCommenter and GUC propagation
 select trace_id, span_operation, parameters, lvl from peek_ordered_spans;
-             trace_id             |   span_operation   |       parameters       | lvl 
-----------------------------------+--------------------+------------------------+-----
- fffffffffffffffffffffffffffffff6 | SELECT $1;         | $1 = 2                 |   1
- fffffffffffffffffffffffffffffff6 | Planner            |                        |   2
- fffffffffffffffffffffffffffffff6 | ExecutorRun        |                        |   2
- fffffffffffffffffffffffffffffff6 | Result             |                        |   3
- fffffffffffffffffffffffffffffff6 | SELECT $1, $2;     | $1 = 1, $2 = 1         |   1
- fffffffffffffffffffffffffffffff6 | Planner            |                        |   2
- fffffffffffffffffffffffffffffff6 | ExecutorRun        |                        |   2
- fffffffffffffffffffffffffffffff6 | Result             |                        |   3
- fffffffffffffffffffffffffffffff6 | SELECT $1, $2, $3; | $1 = 1, $2 = 2, $3 = 3 |   1
- fffffffffffffffffffffffffffffff6 | Planner            |                        |   2
- fffffffffffffffffffffffffffffff6 | ExecutorRun        |                        |   2
- fffffffffffffffffffffffffffffff6 | Result             |                        |   3
- fffffffffffffffffffffffffffffff6 | SELECT $1;         | $1 = 3                 |   1
- fffffffffffffffffffffffffffffff6 | Planner            |                        |   2
- fffffffffffffffffffffffffffffff6 | ExecutorRun        |                        |   2
- fffffffffffffffffffffffffffffff6 | Result             |                        |   3
+             trace_id             |   span_operation   | parameters | lvl 
+----------------------------------+--------------------+------------+-----
+ fffffffffffffffffffffffffffffff6 | SELECT $1;         | {2}        |   1
+ fffffffffffffffffffffffffffffff6 | Planner            |            |   2
+ fffffffffffffffffffffffffffffff6 | ExecutorRun        |            |   2
+ fffffffffffffffffffffffffffffff6 | Result             |            |   3
+ fffffffffffffffffffffffffffffff6 | SELECT $1, $2;     | {1,1}      |   1
+ fffffffffffffffffffffffffffffff6 | Planner            |            |   2
+ fffffffffffffffffffffffffffffff6 | ExecutorRun        |            |   2
+ fffffffffffffffffffffffffffffff6 | Result             |            |   3
+ fffffffffffffffffffffffffffffff6 | SELECT $1, $2, $3; | {1,2,3}    |   1
+ fffffffffffffffffffffffffffffff6 | Planner            |            |   2
+ fffffffffffffffffffffffffffffff6 | ExecutorRun        |            |   2
+ fffffffffffffffffffffffffffffff6 | Result             |            |   3
+ fffffffffffffffffffffffffffffff6 | SELECT $1;         | {3}        |   1
+ fffffffffffffffffffffffffffffff6 | Planner            |            |   2
+ fffffffffffffffffffffffffffffff6 | ExecutorRun        |            |   2
+ fffffffffffffffffffffffffffffff6 | Result             |            |   3
 (16 rows)
 
 CALL clean_spans();

--- a/expected/json.out
+++ b/expected/json.out
@@ -29,18 +29,18 @@ SELECT trace_id, name, kind, lvl FROM peek_ordered_json_spans;
 (8 rows)
 
 -- Test plan attributes with json export
-SELECT trace_id, name, plan_startup_cost, plan_total_cost, plan_rows, plan_width, lvl FROM peek_ordered_json_spans;
-             trace_id             |    name     | plan_startup_cost | plan_total_cost | plan_rows | plan_width | lvl 
-----------------------------------+-------------+-------------------+-----------------+-----------+------------+-----
- 00000000000000000000000000000001 | SELECT $1;  |                   |                 |           |            |   1
- 00000000000000000000000000000001 | Planner     |                   |                 |           |            |   2
- 00000000000000000000000000000001 | ExecutorRun |                   |                 |           |            |   2
- 00000000000000000000000000000001 | Result      |                   |            0.01 |         1 |          4 |   3
- 00000000000000000000000000000002 | SELECT $1, +|                   |                 |           |            |   1
-                                  | $2;         |                   |                 |           |            | 
- 00000000000000000000000000000002 | Planner     |                   |                 |           |            |   2
- 00000000000000000000000000000002 | ExecutorRun |                   |                 |           |            |   2
- 00000000000000000000000000000002 | Result      |                   |            0.01 |         1 |          8 |   3
+SELECT trace_id, name, plan_startup_cost, plan_total_cost, plan_rows, plan_width, parameters, lvl FROM peek_ordered_json_spans;
+             trace_id             |    name     | plan_startup_cost | plan_total_cost | plan_rows | plan_width | parameters | lvl 
+----------------------------------+-------------+-------------------+-----------------+-----------+------------+------------+-----
+ 00000000000000000000000000000001 | SELECT $1;  |                   |                 |           |            | {1}        |   1
+ 00000000000000000000000000000001 | Planner     |                   |                 |           |            |            |   2
+ 00000000000000000000000000000001 | ExecutorRun |                   |                 |           |            |            |   2
+ 00000000000000000000000000000001 | Result      |                   |            0.01 |         1 |          4 |            |   3
+ 00000000000000000000000000000002 | SELECT $1, +|                   |                 |           |            | {1,2}      |   1
+                                  | $2;         |                   |                 |           |            |            | 
+ 00000000000000000000000000000002 | Planner     |                   |                 |           |            |            |   2
+ 00000000000000000000000000000002 | ExecutorRun |                   |                 |           |            |            |   2
+ 00000000000000000000000000000002 | Result      |                   |            0.01 |         1 |          8 |            |   3
 (8 rows)
 
 CALL clean_spans();
@@ -99,7 +99,7 @@ CALL clean_spans();
 SELECT trace_id, name, parameters, deparse_info, lvl FROM peek_ordered_json_spans;
              trace_id             |                        name                         | parameters |    deparse_info     | lvl 
 ----------------------------------+-----------------------------------------------------+------------+---------------------+-----
- 00000000000000000000000000000001 | SELECT * FROM pg_tracing_test WHERE a=$1;           | $1 = 1     |                     |   1
+ 00000000000000000000000000000001 | SELECT * FROM pg_tracing_test WHERE a=$1;           | {1}        |                     |   1
  00000000000000000000000000000001 | Planner                                             |            |                     |   2
  00000000000000000000000000000001 | ExecutorRun                                         |            |                     |   2
  00000000000000000000000000000001 | IndexScan using pg_tracing_index on pg_tracing_test |            | Index Cond: (a = 1) |   3

--- a/expected/planstate.out
+++ b/expected/planstate.out
@@ -44,7 +44,7 @@ SET pg_tracing.deparse_plan=false;
 SELECT span_operation, deparse_info, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000003';
                    span_operation                    | deparse_info | parameters | lvl 
 -----------------------------------------------------+--------------+------------+-----
- SELECT * from pg_tracing_test where a=$1;           |              | $1 = 1     |   1
+ SELECT * from pg_tracing_test where a=$1;           |              | {1}        |   1
  Planner                                             |              |            |   2
  ExecutorRun                                         |              |            |   2
  IndexScan using pg_tracing_index on pg_tracing_test |              |            |   3
@@ -61,7 +61,7 @@ SET pg_tracing.deparse_plan=true;
 SELECT span_operation, deparse_info, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000004';
                    span_operation                    |    deparse_info     | parameters | lvl 
 -----------------------------------------------------+---------------------+------------+-----
- SELECT * from pg_tracing_test where a=$1;           |                     | $1 = 1     |   1
+ SELECT * from pg_tracing_test where a=$1;           |                     | {1}        |   1
  Planner                                             |                     |            |   2
  ExecutorRun                                         |                     |            |   2
  IndexScan using pg_tracing_index on pg_tracing_test | Index Cond: (a = 1) |            |   3

--- a/expected/planstate_bitmap.out
+++ b/expected/planstate_bitmap.out
@@ -7,16 +7,16 @@
 (3 rows)
 
 SELECT span_operation, deparse_info, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000001';
-                      span_operation                       |                 deparse_info                  |       parameters       | lvl 
------------------------------------------------------------+-----------------------------------------------+------------------------+-----
- SELECT * from pg_tracing_test where a=$1 OR a=$2 OR a=$3; |                                               | $1 = 1, $2 = 2, $3 = 3 |   1
- Planner                                                   |                                               |                        |   2
- ExecutorRun                                               |                                               |                        |   2
- BitmapHeapScan on pg_tracing_test                         | Recheck Cond: ((a = 1) OR (a = 2) OR (a = 3)) |                        |   3
- BitmapOr                                                  |                                               |                        |   4
- BitmapIndexScan on pg_tracing_index                       | Index Cond: (a = 1)                           |                        |   5
- BitmapIndexScan on pg_tracing_index                       | Index Cond: (a = 2)                           |                        |   5
- BitmapIndexScan on pg_tracing_index                       | Index Cond: (a = 3)                           |                        |   5
+                      span_operation                       |                 deparse_info                  | parameters | lvl 
+-----------------------------------------------------------+-----------------------------------------------+------------+-----
+ SELECT * from pg_tracing_test where a=$1 OR a=$2 OR a=$3; |                                               | {1,2,3}    |   1
+ Planner                                                   |                                               |            |   2
+ ExecutorRun                                               |                                               |            |   2
+ BitmapHeapScan on pg_tracing_test                         | Recheck Cond: ((a = 1) OR (a = 2) OR (a = 3)) |            |   3
+ BitmapOr                                                  |                                               |            |   4
+ BitmapIndexScan on pg_tracing_index                       | Index Cond: (a = 1)                           |            |   5
+ BitmapIndexScan on pg_tracing_index                       | Index Cond: (a = 2)                           |            |   5
+ BitmapIndexScan on pg_tracing_index                       | Index Cond: (a = 3)                           |            |   5
 (8 rows)
 
 --

--- a/expected/planstate_projectset.out
+++ b/expected/planstate_projectset.out
@@ -7,15 +7,15 @@
 (3 rows)
 
 SELECT span_operation, deparse_info, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000001';
-                                                                                              span_operation                                                                                              | deparse_info |               parameters               | lvl 
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------+----------------------------------------+-----
- select information_schema._pg_expandarray($1::int[]);                                                                                                                                                    |              | $1 = '{0,1,2}'                         |   1
- Planner                                                                                                                                                                                                  |              |                                        |   2
- ExecutorRun                                                                                                                                                                                              |              |                                        |   2
- ProjectSet                                                                                                                                                                                               |              |                                        |   3
- Result                                                                                                                                                                                                   |              |                                        |   4
- select $1[s], s operator(pg_catalog.-) pg_catalog.array_lower($1,$2) operator(pg_catalog.+) $3 from pg_catalog.generate_series(pg_catalog.array_lower($1,$4), pg_catalog.array_upper($1,$5), $6) as g(s) |              | $1 = 1, $2 = 1, $3 = 1, $4 = 1, $5 = 1 |   4
- Planner                                                                                                                                                                                                  |              |                                        |   5
+                                                                                              span_operation                                                                                              | deparse_info |  parameters   | lvl 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------+---------------+-----
+ select information_schema._pg_expandarray($1::int[]);                                                                                                                                                    |              | {"'{0,1,2}'"} |   1
+ Planner                                                                                                                                                                                                  |              |               |   2
+ ExecutorRun                                                                                                                                                                                              |              |               |   2
+ ProjectSet                                                                                                                                                                                               |              |               |   3
+ Result                                                                                                                                                                                                   |              |               |   4
+ select $1[s], s operator(pg_catalog.-) pg_catalog.array_lower($1,$2) operator(pg_catalog.+) $3 from pg_catalog.generate_series(pg_catalog.array_lower($1,$4), pg_catalog.array_upper($1,$5), $6) as g(s) |              | {1,1,1,1,1}   |   4
+ Planner                                                                                                                                                                                                  |              |               |   5
 (7 rows)
 
 -- +---------------------------------------------+

--- a/expected/planstate_subplans.out
+++ b/expected/planstate_subplans.out
@@ -5,16 +5,16 @@ WHEN MATCHED THEN UPDATE SET v = (SELECT b || ' merge update' FROM cte_init WHER
 WHEN NOT MATCHED THEN INSERT VALUES(o.k, o.v);
 -- Check generated spans for init plan
 SELECT span_operation, deparse_info, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000001' AND lvl < 4;
-                                    span_operation                                     | deparse_info |                                                   parameters                                                    | lvl 
----------------------------------------------------------------------------------------+--------------+-----------------------------------------------------------------------------------------------------------------+-----
- WITH cte_init AS MATERIALIZED (SELECT $1 a, $2 b)                                    +|              | $1 = 1, $2 = 'cte_init val', $3 = 1, $4 = 'merge source InitPlan', $5 = 0, $6 = ' merge update', $7 = 1, $8 = 1 |   1
- MERGE INTO m USING (select $3 k, $4 v offset $5) o ON m.k=o.k                        +|              |                                                                                                                 | 
- WHEN MATCHED THEN UPDATE SET v = (SELECT b || $6 FROM cte_init WHERE a = $7 LIMIT $8)+|              |                                                                                                                 | 
- WHEN NOT MATCHED THEN INSERT VALUES(o.k, o.v);                                        |              |                                                                                                                 | 
- Planner                                                                               |              |                                                                                                                 |   2
- ExecutorRun                                                                           |              |                                                                                                                 |   2
- Merge on m                                                                            |              |                                                                                                                 |   3
- Commit                                                                                |              |                                                                                                                 |   1
+                                    span_operation                                     | deparse_info |                                parameters                                | lvl 
+---------------------------------------------------------------------------------------+--------------+--------------------------------------------------------------------------+-----
+ WITH cte_init AS MATERIALIZED (SELECT $1 a, $2 b)                                    +|              | {1,"'cte_init val'",1,"'merge source InitPlan'",0,"' merge update'",1,1} |   1
+ MERGE INTO m USING (select $3 k, $4 v offset $5) o ON m.k=o.k                        +|              |                                                                          | 
+ WHEN MATCHED THEN UPDATE SET v = (SELECT b || $6 FROM cte_init WHERE a = $7 LIMIT $8)+|              |                                                                          | 
+ WHEN NOT MATCHED THEN INSERT VALUES(o.k, o.v);                                        |              |                                                                          | 
+ Planner                                                                               |              |                                                                          |   2
+ ExecutorRun                                                                           |              |                                                                          |   2
+ Merge on m                                                                            |              |                                                                          |   3
+ Commit                                                                                |              |                                                                          |   1
 (5 rows)
 
 -- +----------------------------------------------------------+

--- a/expected/planstate_union.out
+++ b/expected/planstate_union.out
@@ -10,18 +10,18 @@ SELECT count(*) FROM pg_tracing_test WHERE a + 0 < 10000;
 (2 rows)
 
 SELECT span_operation, deparse_info, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000001';
-                     span_operation                      |        deparse_info        |             parameters              | lvl 
----------------------------------------------------------+----------------------------+-------------------------------------+-----
- SELECT count(*) FROM pg_tracing_test WHERE a + $1 < $2 +|                            | $1 = 0, $2 = 10, $3 = 0, $4 = 10000 |   1
- UNION ALL                                              +|                            |                                     | 
- SELECT count(*) FROM pg_tracing_test WHERE a + $3 < $4; |                            |                                     | 
- Planner                                                 |                            |                                     |   2
- ExecutorRun                                             |                            |                                     |   2
- Append                                                  |                            |                                     |   3
- Aggregate                                               |                            |                                     |   4
- SeqScan on pg_tracing_test                              | Filter : ((a + 0) < 10)    |                                     |   5
- Aggregate                                               |                            |                                     |   4
- SeqScan on pg_tracing_test pg_tracing_test_1            | Filter : ((a + 0) < 10000) |                                     |   5
+                     span_operation                      |        deparse_info        |   parameters   | lvl 
+---------------------------------------------------------+----------------------------+----------------+-----
+ SELECT count(*) FROM pg_tracing_test WHERE a + $1 < $2 +|                            | {0,10,0,10000} |   1
+ UNION ALL                                              +|                            |                | 
+ SELECT count(*) FROM pg_tracing_test WHERE a + $3 < $4; |                            |                | 
+ Planner                                                 |                            |                |   2
+ ExecutorRun                                             |                            |                |   2
+ Append                                                  |                            |                |   3
+ Aggregate                                               |                            |                |   4
+ SeqScan on pg_tracing_test                              | Filter : ((a + 0) < 10)    |                |   5
+ Aggregate                                               |                            |                |   4
+ SeqScan on pg_tracing_test pg_tracing_test_1            | Filter : ((a + 0) < 10000) |                |   5
 (8 rows)
 
 -- +------------------------------------------+

--- a/expected/sample.out
+++ b/expected/sample.out
@@ -65,19 +65,19 @@ select count(distinct(trace_id)) from pg_tracing_peek_spans;
 select span_operation, parameters, lvl from peek_ordered_spans;
  span_operation | parameters | lvl 
 ----------------+------------+-----
- SELECT $1;     | $1 = 1     |   1
+ SELECT $1;     | {1}        |   1
  Planner        |            |   2
  ExecutorRun    |            |   2
  Result         |            |   3
- SELECT $1;     | $1 = 2     |   1
+ SELECT $1;     | {2}        |   1
  Planner        |            |   2
  ExecutorRun    |            |   2
  Result         |            |   3
- SELECT $1;     | $1 = 3     |   1
+ SELECT $1;     | {3}        |   1
  Planner        |            |   2
  ExecutorRun    |            |   2
  Result         |            |   3
- SELECT $1;     | $1 = 4     |   1
+ SELECT $1;     | {4}        |   1
  Planner        |            |   2
  ExecutorRun    |            |   2
  Result         |            |   3
@@ -87,10 +87,10 @@ select span_operation, parameters, lvl from peek_ordered_spans;
 select span_operation, parameters from peek_ordered_spans where right(trace_id, 16) = parent_id;
  span_operation | parameters 
 ----------------+------------
- SELECT $1;     | $1 = 1
- SELECT $1;     | $1 = 2
- SELECT $1;     | $1 = 3
- SELECT $1;     | $1 = 4
+ SELECT $1;     | {1}
+ SELECT $1;     | {2}
+ SELECT $1;     | {3}
+ SELECT $1;     | {4}
 (4 rows)
 
 CALL clean_spans();
@@ -143,15 +143,15 @@ select distinct(trace_id) from pg_tracing_peek_spans order by trace_id;
 select span_operation, parameters, lvl from peek_ordered_spans;
  span_operation | parameters | lvl 
 ----------------+------------+-----
- SELECT $1;     | $1 = 1     |   1
+ SELECT $1;     | {1}        |   1
  Planner        |            |   2
  ExecutorRun    |            |   2
  Result         |            |   3
- SELECT $1;     | $1 = 3     |   1
+ SELECT $1;     | {3}        |   1
  Planner        |            |   2
  ExecutorRun    |            |   2
  Result         |            |   3
- SELECT $1;     | $1 = 4     |   1
+ SELECT $1;     | {4}        |   1
  Planner        |            |   2
  ExecutorRun    |            |   2
  Result         |            |   3

--- a/expected/select.out
+++ b/expected/select.out
@@ -14,7 +14,7 @@ SELECT span_id AS top_span_id from pg_tracing_peek_spans where parent_id='000000
 SELECT parameters from pg_tracing_peek_spans where span_id=:'top_span_id';
  parameters 
 ------------
- $1 = 1
+ {1}
 (1 row)
 
 -- Check the number of children
@@ -143,12 +143,12 @@ SET plan_cache_mode='auto';
 (0 rows)
 
 SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='0000000000000000000000000000000b';
-   span_operation    |   parameters   | lvl 
----------------------+----------------+-----
- select $1 limit $2; | $1 = 1, $2 = 0 |   1
- Planner             |                |   2
- ExecutorRun         |                |   2
- Limit               |                |   3
+   span_operation    | parameters | lvl 
+---------------------+------------+-----
+ select $1 limit $2; | {1,0}      |   1
+ Planner             |            |   2
+ ExecutorRun         |            |   2
+ Limit               |            |   3
 (4 rows)
 
 -- Test multiple statements in a single query
@@ -166,7 +166,7 @@ SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='0
 SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='0000000000000000000000000000000c';
  span_operation | parameters | lvl 
 ----------------+------------+-----
- select $1;     | $1 = 1     |   1
+ select $1;     | {1}        |   1
  Planner        |            |   2
  ExecutorRun    |            |   2
  Result         |            |   3
@@ -206,16 +206,16 @@ SELECT 1\; SELECT 1, 2;
 (1 row)
 
 SELECT span_type, span_operation, parameters, lvl from peek_ordered_spans;
-  span_type   | span_operation |   parameters   | lvl 
---------------+----------------+----------------+-----
- Select query | SELECT $1;     | $1 = 1         |   1
- Planner      | Planner        |                |   2
- ExecutorRun  | ExecutorRun    |                |   2
- Result       | Result         |                |   3
- Select query | SELECT $1, $2; | $1 = 1, $2 = 2 |   1
- Planner      | Planner        |                |   2
- ExecutorRun  | ExecutorRun    |                |   2
- Result       | Result         |                |   3
+  span_type   | span_operation | parameters | lvl 
+--------------+----------------+------------+-----
+ Select query | SELECT $1;     | {1}        |   1
+ Planner      | Planner        |            |   2
+ ExecutorRun  | ExecutorRun    |            |   2
+ Result       | Result         |            |   3
+ Select query | SELECT $1, $2; | {1,2}      |   1
+ Planner      | Planner        |            |   2
+ ExecutorRun  | ExecutorRun    |            |   2
+ Result       | Result         |            |   3
 (8 rows)
 
 CALL clean_spans();
@@ -243,7 +243,7 @@ ERROR:  invalid input syntax for type integer: "\xdeadbeef"
 SELECT span_type, span_operation, parameters, sql_error_code, lvl from peek_ordered_spans;
   span_type   |        span_operation        |    parameters     | sql_error_code | lvl 
 --------------+------------------------------+-------------------+----------------+-----
- Select query | SELECT $1::bytea::text::int; | $1 = '\xDEADBEEF' | 22P02          |   1
+ Select query | SELECT $1::bytea::text::int; | {"'\\xDEADBEEF'"} | 22P02          |   1
  Planner      | Planner                      |                   | 22P02          |   2
 (2 rows)
 
@@ -263,18 +263,18 @@ SELECT lazy_function('{1,2,3,4}'::int[]) FROM (VALUES (1,2)) as t;
 (4 rows)
 
 SELECT span_type, span_operation, parameters, lvl from peek_ordered_spans;
-   span_type    |                                                                                             span_operation                                                                                              |            parameters            | lvl 
-----------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------+-----
- Utility query  | CREATE OR REPLACE FUNCTION lazy_function(IN anyarray, OUT x anyelement) RETURNS SETOF anyelement LANGUAGE sql AS 'select * from pg_catalog.generate_series(array_lower($1, 1), array_upper($1, 1), 1)'; |                                  |   1
- ProcessUtility | ProcessUtility                                                                                                                                                                                          |                                  |   2
- Commit         | Commit                                                                                                                                                                                                  |                                  |   1
- Select query   | SELECT lazy_function($1::int[]) FROM (VALUES ($2,$3)) as t;                                                                                                                                             | $1 = '{1,2,3,4}', $2 = 1, $3 = 2 |   1
- Planner        | Planner                                                                                                                                                                                                 |                                  |   2
- ExecutorRun    | ExecutorRun                                                                                                                                                                                             |                                  |   2
- ProjectSet     | ProjectSet                                                                                                                                                                                              |                                  |   3
- Result         | Result                                                                                                                                                                                                  |                                  |   4
- Select query   | select * from pg_catalog.generate_series(array_lower($1, $2), array_upper($1, $3), $4)                                                                                                                  | $1 = 1, $2 = 1, $3 = 1           |   4
- Planner        | Planner                                                                                                                                                                                                 |                                  |   5
+   span_type    |                                                                                             span_operation                                                                                              |     parameters      | lvl 
+----------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------+-----
+ Utility query  | CREATE OR REPLACE FUNCTION lazy_function(IN anyarray, OUT x anyelement) RETURNS SETOF anyelement LANGUAGE sql AS 'select * from pg_catalog.generate_series(array_lower($1, 1), array_upper($1, 1), 1)'; |                     |   1
+ ProcessUtility | ProcessUtility                                                                                                                                                                                          |                     |   2
+ Commit         | Commit                                                                                                                                                                                                  |                     |   1
+ Select query   | SELECT lazy_function($1::int[]) FROM (VALUES ($2,$3)) as t;                                                                                                                                             | {"'{1,2,3,4}'",1,2} |   1
+ Planner        | Planner                                                                                                                                                                                                 |                     |   2
+ ExecutorRun    | ExecutorRun                                                                                                                                                                                             |                     |   2
+ ProjectSet     | ProjectSet                                                                                                                                                                                              |                     |   3
+ Result         | Result                                                                                                                                                                                                  |                     |   4
+ Select query   | select * from pg_catalog.generate_series(array_lower($1, $2), array_upper($1, $3), $4)                                                                                                                  | {1,1,1}             |   4
+ Planner        | Planner                                                                                                                                                                                                 |                     |   5
 (10 rows)
 
 CALL clean_spans();
@@ -288,7 +288,7 @@ SELECT information_schema._pg_truetypid(a, t) FROM pg_attribute a, pg_type t lim
 SELECT span_type, span_operation, parameters, lvl from peek_ordered_spans;
   span_type   |                                     span_operation                                     | parameters | lvl 
 --------------+----------------------------------------------------------------------------------------+------------+-----
- Select query | SELECT information_schema._pg_truetypid(a, t) FROM pg_attribute a, pg_type t limit $1; | $1 = 1     |   1
+ Select query | SELECT information_schema._pg_truetypid(a, t) FROM pg_attribute a, pg_type t limit $1; | {1}        |   1
  Planner      | Planner                                                                                |            |   2
  ExecutorRun  | ExecutorRun                                                                            |            |   2
  Limit        | Limit                                                                                  |            |   3

--- a/expected/subxact.out
+++ b/expected/subxact.out
@@ -16,35 +16,35 @@ SELECT 1;
 COMMIT;
 -- Check that subxact_count is correctly reported
 select span_operation, parameters, subxact_count, lvl FROM peek_ordered_spans;
-                          span_operation                          |         parameters         | subxact_count | lvl 
-------------------------------------------------------------------+----------------------------+---------------+-----
- BEGIN;                                                           |                            |             0 |   1
- ProcessUtility                                                   |                            |             0 |   2
- SAVEPOINT s1;                                                    |                            |             0 |   1
- ProcessUtility                                                   |                            |             0 |   2
- INSERT INTO pg_tracing_test VALUES(generate_series($1, $2), $3); | $1 = 1, $2 = 2, $3 = 'aaa' |             0 |   1
- Planner                                                          |                            |             0 |   2
- ExecutorRun                                                      |                            |             0 |   2
- Insert on pg_tracing_test                                        |                            |             1 |   3
- ProjectSet                                                       |                            |             1 |   4
- Result                                                           |                            |             1 |   5
- SAVEPOINT s2;                                                    |                            |             1 |   1
- ProcessUtility                                                   |                            |             1 |   2
- INSERT INTO pg_tracing_test VALUES(generate_series($1, $2), $3); | $1 = 1, $2 = 2, $3 = 'aaa' |             1 |   1
- Planner                                                          |                            |             1 |   2
- ExecutorRun                                                      |                            |             1 |   2
- Insert on pg_tracing_test                                        |                            |             2 |   3
- ProjectSet                                                       |                            |             2 |   4
- Result                                                           |                            |             2 |   5
- SAVEPOINT s3;                                                    |                            |             2 |   1
- ProcessUtility                                                   |                            |             2 |   2
- SELECT $1;                                                       | $1 = 1                     |             2 |   1
- Planner                                                          |                            |             2 |   2
- ExecutorRun                                                      |                            |             2 |   2
- Result                                                           |                            |             2 |   3
- COMMIT;                                                          |                            |             2 |   1
- ProcessUtility                                                   |                            |             2 |   2
- Commit                                                           |                            |             2 |   1
+                          span_operation                          | parameters  | subxact_count | lvl 
+------------------------------------------------------------------+-------------+---------------+-----
+ BEGIN;                                                           |             |             0 |   1
+ ProcessUtility                                                   |             |             0 |   2
+ SAVEPOINT s1;                                                    |             |             0 |   1
+ ProcessUtility                                                   |             |             0 |   2
+ INSERT INTO pg_tracing_test VALUES(generate_series($1, $2), $3); | {1,2,'aaa'} |             0 |   1
+ Planner                                                          |             |             0 |   2
+ ExecutorRun                                                      |             |             0 |   2
+ Insert on pg_tracing_test                                        |             |             1 |   3
+ ProjectSet                                                       |             |             1 |   4
+ Result                                                           |             |             1 |   5
+ SAVEPOINT s2;                                                    |             |             1 |   1
+ ProcessUtility                                                   |             |             1 |   2
+ INSERT INTO pg_tracing_test VALUES(generate_series($1, $2), $3); | {1,2,'aaa'} |             1 |   1
+ Planner                                                          |             |             1 |   2
+ ExecutorRun                                                      |             |             1 |   2
+ Insert on pg_tracing_test                                        |             |             2 |   3
+ ProjectSet                                                       |             |             2 |   4
+ Result                                                           |             |             2 |   5
+ SAVEPOINT s3;                                                    |             |             2 |   1
+ ProcessUtility                                                   |             |             2 |   2
+ SELECT $1;                                                       | {1}         |             2 |   1
+ Planner                                                          |             |             2 |   2
+ ExecutorRun                                                      |             |             2 |   2
+ Result                                                           |             |             2 |   3
+ COMMIT;                                                          |             |             2 |   1
+ ProcessUtility                                                   |             |             2 |   2
+ Commit                                                           |             |             2 |   1
 (27 rows)
 
 -- Cleaning

--- a/expected/utility.out
+++ b/expected/utility.out
@@ -89,6 +89,13 @@ CREATE FUNCTION get_string_attribute(attributes jsonb, keyvalue text) returns te
     IMMUTABLE
     RETURN (jsonb_path_query_first(jsonb_path_query_first(attributes, '$ ? (@.key == $key)', jsonb_build_object('key', keyvalue)),
                                    '$.value.stringValue')) ->>0;
+CREATE FUNCTION get_string_array_attribute(attributes jsonb, keyvalue text) returns text[]
+    LANGUAGE SQL
+    IMMUTABLE
+    RETURN (SELECT NULLIF(ARRAY(SELECT jsonb_array_elements_text(jsonb_path_query_array(
+                jsonb_path_query_first(attributes,
+                                       '$ ? (@.key == $key)', jsonb_build_object('key', keyvalue)),
+                                       '$.value.arrayValue.values[*].stringValue[*]'))), '{}'));
 -- View spans generated from json with their nested level
 -- TODO: There's probably a way to make this cleaner...
 CREATE VIEW peek_json_spans_with_level AS
@@ -142,7 +149,7 @@ WITH RECURSIVE list_trace_spans(trace_id, parent_id, span_id, name, span_start, 
             get_double_attribute(p.attributes, 'jit.optimization_counter'),
             get_double_attribute(p.attributes, 'jit.emission_counter'),
             get_double_attribute(p.attributes, 'query.startup'),
-            get_string_attribute(p.attributes, 'query.parameters'),
+            get_string_array_attribute(p.attributes, 'query.parameters'),
             get_string_attribute(p.attributes, 'query.deparse_info'),
             1
         FROM peek_json_spans p where not "parentSpanId"=ANY(SELECT span_id from pg_tracing_peek_spans)
@@ -184,7 +191,7 @@ WITH RECURSIVE list_trace_spans(trace_id, parent_id, span_id, name, span_start, 
             get_double_attribute(s.attributes, 'jit.optimization_counter'),
             get_double_attribute(s.attributes, 'jit.emission_counter'),
             get_double_attribute(s.attributes, 'query.startup'),
-            get_string_attribute(s.attributes, 'query.parameters'),
+            get_string_array_attribute(s.attributes, 'query.parameters'),
             get_string_attribute(s.attributes, 'query.deparse_info'),
             lvl + 1
         FROM peek_json_spans s, list_trace_spans st
@@ -260,7 +267,7 @@ select span_operation, parameters, lvl from peek_ordered_spans;
  PREPARE test_prepared_one_param_2 (integer) AS SELECT $1; |            |   3
  EXECUTE test_prepared_one_param_2(100);                   |            |   1
  ProcessUtility                                            |            |   2
- PREPARE test_prepared_one_param_2 (integer) AS SELECT $1; | $1 = '100' |   3
+ PREPARE test_prepared_one_param_2 (integer) AS SELECT $1; | {100}      |   3
  Planner                                                   |            |   4
  ExecutorRun                                               |            |   4
  Result                                                    |            |   5
@@ -280,16 +287,16 @@ PREPARE test_insert (integer, text) AS INSERT INTO pg_tracing_test(a, b) VALUES 
 /*dddbs='postgres.db',traceparent='00-00000000000000000000000000000001-0000000000000001-01'*/ EXECUTE test_insert(100, '2');
 -- Check spans of test_insert execution
 select trace_id, span_operation, parameters, lvl from peek_ordered_spans WHERE trace_id='00000000000000000000000000000001';
-             trace_id             |                                      span_operation                                       |      parameters      | lvl 
-----------------------------------+-------------------------------------------------------------------------------------------+----------------------+-----
- 00000000000000000000000000000001 | EXECUTE test_insert(100, '2');                                                            |                      |   1
- 00000000000000000000000000000001 | ProcessUtility                                                                            |                      |   2
- 00000000000000000000000000000001 | PREPARE test_insert (integer, text) AS INSERT INTO pg_tracing_test(a, b) VALUES ($1, $2); | $1 = '100', $2 = '2' |   3
- 00000000000000000000000000000001 | Planner                                                                                   |                      |   4
- 00000000000000000000000000000001 | ExecutorRun                                                                               |                      |   4
- 00000000000000000000000000000001 | Insert on pg_tracing_test                                                                 |                      |   5
- 00000000000000000000000000000001 | Result                                                                                    |                      |   6
- 00000000000000000000000000000001 | Commit                                                                                    |                      |   1
+             trace_id             |                                      span_operation                                       | parameters | lvl 
+----------------------------------+-------------------------------------------------------------------------------------------+------------+-----
+ 00000000000000000000000000000001 | EXECUTE test_insert(100, '2');                                                            |            |   1
+ 00000000000000000000000000000001 | ProcessUtility                                                                            |            |   2
+ 00000000000000000000000000000001 | PREPARE test_insert (integer, text) AS INSERT INTO pg_tracing_test(a, b) VALUES ($1, $2); | {100,2}    |   3
+ 00000000000000000000000000000001 | Planner                                                                                   |            |   4
+ 00000000000000000000000000000001 | ExecutorRun                                                                               |            |   4
+ 00000000000000000000000000000001 | Insert on pg_tracing_test                                                                 |            |   5
+ 00000000000000000000000000000001 | Result                                                                                    |            |   6
+ 00000000000000000000000000000001 | Commit                                                                                    |            |   1
 (8 rows)
 
 -- We should have only two query_ids

--- a/pg_tracing--0.1.0.sql
+++ b/pg_tracing--0.1.0.sql
@@ -84,7 +84,7 @@ CREATE FUNCTION pg_tracing_spans(
 
 --  Span node specific data
     OUT startup bigint, -- First tuple
-    OUT parameters text,
+    OUT parameters text[],
     OUT deparse_info text
 )
 RETURNS SETOF record

--- a/sql/json.sql
+++ b/sql/json.sql
@@ -6,7 +6,7 @@
 -- Check json generated spans for simple and multi line query
 SELECT trace_id, name, kind, lvl FROM peek_ordered_json_spans;
 -- Test plan attributes with json export
-SELECT trace_id, name, plan_startup_cost, plan_total_cost, plan_rows, plan_width, lvl FROM peek_ordered_json_spans;
+SELECT trace_id, name, plan_startup_cost, plan_total_cost, plan_rows, plan_width, parameters, lvl FROM peek_ordered_json_spans;
 CALL clean_spans();
 
 -- Test error code with json export

--- a/src/pg_tracing.c
+++ b/src/pg_tracing.c
@@ -832,9 +832,10 @@ drop_all_spans_locked(void)
 {
 	/* Drop all spans */
 	shared_spans->end = 0;
-
 	/* Reset query file position */
 	pg_tracing_shared_state->extent = 0;
+    /* Update last consume ts */
+    pg_tracing_shared_state->stats.last_consume = GetCurrentTimestamp();
 	pg_truncate(PG_TRACING_TEXT_FILE, 0);
 }
 

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -195,6 +195,10 @@ typedef struct Span
 
 	SpanType	type;			/* Type of the span. Used to generate the
 								 * span's name */
+
+	bool		parallel_aware;
+	bool		async_capable;
+
 	int8		nested_level;	/* Nested level of this span this span.
 								 * Internal usage only */
 	int8		parent_planstate_index; /* Index to the parent planstate of
@@ -204,7 +208,7 @@ typedef struct Span
 	int			be_pid;			/* Pid of the backend process */
 	Oid			user_id;		/* User ID when the span was created */
 	Oid			database_id;	/* Database ID where the span was created */
-	int		    worker_id;	    /* Worker id */
+	int			worker_id;		/* Worker id */
 
 	/*
 	 * We store variable size metadata in an external file. Those represent
@@ -339,7 +343,7 @@ typedef struct SpanContext
 
 /* pg_tracing_explain.c */
 extern SpanType plan_to_span_type(const Plan *plan);
-extern const char *plan_to_operation(const planstateTraceContext * planstateTraceContext, const PlanState *planstate, SpanType span_type);
+extern const char *plan_to_rel_name(const planstateTraceContext * planstateTraceContext, const PlanState *planstate);
 extern const char *plan_to_deparse_info(const planstateTraceContext * planstateTraceContext, const PlanState *planstate);
 
 /* pg_tracing_parallel.c */

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -205,6 +205,8 @@ typedef struct Span
 										 * this span. Internal usage only */
 	uint8		subxact_count;	/* Active count of backend's subtransaction */
 
+	uint16		num_parameters; /* Number of parameters */
+
 	int			be_pid;			/* Pid of the backend process */
 	Oid			user_id;		/* User ID when the span was created */
 	Oid			database_id;	/* Database ID where the span was created */
@@ -333,6 +335,7 @@ typedef struct SpanContext
 {
 	TimestampTz start_time;
 	Traceparent *traceparent;
+	StringInfo	current_trace_text;
 	const PlannedStmt *pstmt;
 	const Query *query;
 	const JumbleState *jstate;
@@ -372,8 +375,8 @@ extern TimestampTz
 
 /* pg_tracing_query_process.c */
 extern const char *normalise_query_parameters(const JumbleState *jstate, const char *query,
-											  int query_loc, int *query_len_p, char **param_str,
-											  int *param_len);
+											  int query_loc, int *query_len_p, StringInfo trace_text,
+											  int *num_parameters);
 extern void extract_trace_context_from_query(Traceparent * traceparent, const char *query);
 extern ParseTraceparentErr parse_trace_context(Traceparent * traceparent, const char *trace_context_str, int trace_context_len);
 extern char *parse_code_to_err(ParseTraceparentErr err);

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -199,11 +199,12 @@ typedef struct Span
 								 * Internal usage only */
 	int8		parent_planstate_index; /* Index to the parent planstate of
 										 * this span. Internal usage only */
+	uint8		subxact_count;	/* Active count of backend's subtransaction */
+
 	int			be_pid;			/* Pid of the backend process */
 	Oid			user_id;		/* User ID when the span was created */
 	Oid			database_id;	/* Database ID where the span was created */
-
-	uint8		subxact_count;	/* Active count of backend's subtransaction */
+	int		    worker_id;	    /* Worker id */
 
 	/*
 	 * We store variable size metadata in an external file. Those represent

--- a/src/pg_tracing_active_spans.c
+++ b/src/pg_tracing_active_spans.c
@@ -171,10 +171,9 @@ begin_active_span(const SpanContext * span_context, Span * span,
 	if (IsParallelWorker())
 	{
 		/*
-		 * In a parallel worker, we use the worker name as the span's
-		 * operation
+		 * We're in a parallel worker, save the worker number operation
 		 */
-		span->operation_name_offset = add_worker_name_to_trace_buffer(ParallelWorkerNumber);
+		span->worker_id = ParallelWorkerNumber;
 		return;
 	}
 

--- a/src/pg_tracing_explain.c
+++ b/src/pg_tracing_explain.c
@@ -396,8 +396,6 @@ plan_to_deparse_info(const planstateTraceContext * planstateTraceContext, const 
 SpanType
 plan_to_span_type(const Plan *plan)
 {
-	const char *custom_name;
-
 	switch (nodeTag(plan))
 	{
 		case T_Result:

--- a/src/pg_tracing_planstate.c
+++ b/src/pg_tracing_planstate.c
@@ -616,12 +616,18 @@ create_span_node(PlanState *planstate, const planstateTraceContext * planstateTr
 		/* Generate node specific variable strings and store them */
 		SpanType	node_type;
 		const char *deparse_info;
-		char const *operation_name;
 		int			deparse_info_len;
+		const char *operation_name;
+		int			len_operation_name;
 
-		node_type = plan_to_span_type(plan);
-		operation_name = plan_to_operation(planstateTraceContext, planstate, node_type);
-		span.operation_name_offset = add_str_to_trace_buffer(operation_name, strlen(operation_name));
+		span.parallel_aware = plan->parallel_aware;
+		span.async_capable = plan->async_capable;
+
+		span_type = plan_to_span_type(plan);
+		operation_name = plan_to_rel_name(planstateTraceContext, planstate);
+		len_operation_name = strlen(operation_name);
+		if (len_operation_name > 0)
+			span.operation_name_offset = add_str_to_trace_buffer(operation_name, len_operation_name);
 
 		/* deparse_ctx is NULL if deparsing was disabled */
 		if (planstateTraceContext->deparse_ctx != NULL)

--- a/src/pg_tracing_planstate.c
+++ b/src/pg_tracing_planstate.c
@@ -614,7 +614,6 @@ create_span_node(PlanState *planstate, const planstateTraceContext * planstateTr
 	if (node_type == SPAN_NODE)
 	{
 		/* Generate node specific variable strings and store them */
-		SpanType	node_type;
 		const char *deparse_info;
 		int			deparse_info_len;
 		const char *operation_name;

--- a/src/pg_tracing_span.c
+++ b/src/pg_tracing_span.c
@@ -41,6 +41,7 @@ begin_span(TraceId trace_id, Span * span, SpanType type,
 	else
 		span->span_id = pg_prng_uint64(&pg_global_prng_state);
 
+	span->worker_id = -1;
 	span->operation_name_offset = -1;
 	span->parameter_offset = -1;
 	span->deparse_info_offset = -1;
@@ -272,6 +273,11 @@ span_type_to_str(SpanType span_type)
 const char *
 get_operation_name(const Span * span, const char *qbuffer, Size qbuffer_size)
 {
+    /* Use worker id when available */
+    if (span->worker_id >= 0) {
+        Assert(span->operation_name_offset == -1);
+        return psprintf("Worker %d", span->worker_id);
+    }
 	if (span->operation_name_offset != -1 && qbuffer_size > 0
 		&& span->operation_name_offset <= qbuffer_size)
 		return qbuffer + span->operation_name_offset;

--- a/src/pg_tracing_span.c
+++ b/src/pg_tracing_span.c
@@ -45,6 +45,7 @@ begin_span(TraceId trace_id, Span * span, SpanType type,
 	span->async_capable = false;
 	span->worker_id = -1;
 	span->operation_name_offset = -1;
+	span->num_parameters = 0;
 	span->parameter_offset = -1;
 	span->deparse_info_offset = -1;
 	span->sql_error_code = 0;
@@ -273,13 +274,6 @@ is_span_top(SpanType span_type)
 {
 	return span_type >= SPAN_TOP_SELECT
 		&& span_type <= SPAN_TOP_UNKNOWN;
-}
-
-static bool
-is_span_node(SpanType span_type)
-{
-	return span_type >= SPAN_NODE
-		&& span_type <= SPAN_NODE_UNKNOWN;
 }
 
 /*

--- a/src/pg_tracing_sql_functions.c
+++ b/src/pg_tracing_sql_functions.c
@@ -222,7 +222,6 @@ pg_tracing_json_spans(PG_FUNCTION_ARGS)
 
 	build_json_context(&json_ctx, qbuffer, qbuffer_size, shared_spans);
 	marshal_spans_to_json(&json_ctx);
-	pg_tracing_shared_state->stats.last_consume = GetCurrentTimestamp();
 	LWLockRelease(pg_tracing_shared_state->lock);
 
 	PG_RETURN_TEXT_P(cstring_to_text(json_ctx.str->data));
@@ -295,7 +294,6 @@ pg_tracing_spans(PG_FUNCTION_ARGS)
 	/* Consume is set, remove spans from the shared buffer */
 	if (consume)
 		drop_all_spans_locked();
-	pg_tracing_shared_state->stats.last_consume = GetCurrentTimestamp();
 	LWLockRelease(pg_tracing_shared_state->lock);
 
 	free(qbuffer);

--- a/t/002_connect_timeout.pl
+++ b/t/002_connect_timeout.pl
@@ -28,6 +28,10 @@ $node->safe_psql("postgres", "/*dddbs='postgres.db',traceparent='00-000000000000
 ok( $node->poll_query_until('postgres', "SELECT otel_failures >= 1 FROM pg_tracing_info;"),
     "Otel failures should be reported");
 
+my $result =
+  $node->safe_psql('postgres', "SELECT count(*) FROM pg_tracing_peek_spans;");
+is($result, qq(4), "Query's spans should still be present");
+
 # Cleanup
 $node->stop;
 


### PR DESCRIPTION
- Keep worker id in the span instead of keeping "Worker x" in the query text.
- Don't repeat span_type in the operation name. For names like "Index Scan on table", "index scan" can be generated from the span_type so only store "on table" in the query text
- Ourtput parameters as text[] insteand of a single string