### PR TITLE
Fix set of trace_id for tx_start_traceparent

### DIFF
--- a/expected/transaction.out
+++ b/expected/transaction.out
@@ -21,6 +21,7 @@ SELECT span_type, span_operation, lvl FROM peek_ordered_spans where trace_id='00
  ProcessUtility | ProcessUtility |   2
 (8 rows)
 
+CALL clean_spans();
 -- Test with override of the trace context in the middle of a transaction
 /*dddbs='postgres.db',traceparent='00-00000000000000000000000000000002-0000000000000002-01'*/ BEGIN;
 /*dddbs='postgres.db',traceparent='00-00000000000000000000000000000003-0000000000000003-01'*/ SELECT 1; COMMIT;
@@ -46,6 +47,102 @@ SELECT span_type, span_operation, lvl FROM peek_ordered_spans where trace_id='00
  ExecutorRun  | ExecutorRun    |   2
  Result       | Result         |   3
 (4 rows)
+
+CALL clean_spans();
+-- Test with a 0 traceid in the middle of a transaction
+BEGIN;
+SELECT 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000000-0000000000000001-01'*/ SELECT 2;
+ ?column? 
+----------
+        2
+(1 row)
+
+SELECT 3;
+ ?column? 
+----------
+        3
+(1 row)
+
+/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000000-0000000000000001-01'*/ SELECT 4;
+ ?column? 
+----------
+        4
+(1 row)
+
+END;
+-- Only one trace id should have been generated
+SELECT count(distinct(trace_id)) = 1 FROM pg_tracing_peek_spans;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT span_type, span_operation, lvl FROM peek_ordered_spans;
+  span_type   | span_operation | lvl 
+--------------+----------------+-----
+ Select query | SELECT $1;     |   1
+ Planner      | Planner        |   2
+ ExecutorRun  | ExecutorRun    |   2
+ Result       | Result         |   3
+ Select query | SELECT $1;     |   1
+ Planner      | Planner        |   2
+ ExecutorRun  | ExecutorRun    |   2
+ Result       | Result         |   3
+(8 rows)
+
+CALL clean_spans();
+-- Test with a 0 parent_id in the middle of a transaction
+BEGIN;
+SELECT 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000000-0000000000000000-01'*/ SELECT 2;
+ ?column? 
+----------
+        2
+(1 row)
+
+SELECT 3;
+ ?column? 
+----------
+        3
+(1 row)
+
+/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000000-0000000000000000-01'*/ SELECT 4;
+ ?column? 
+----------
+        4
+(1 row)
+
+END;
+-- Only one trace id and parent id should have been generated
+SELECT count(distinct(trace_id)) = 1, count(distinct(parent_id)) = 1 FROM peek_ordered_spans WHERE lvl=1;
+ ?column? | ?column? 
+----------+----------
+ t        | t
+(1 row)
+
+SELECT span_type, span_operation, lvl FROM peek_ordered_spans;
+  span_type   | span_operation | lvl 
+--------------+----------------+-----
+ Select query | SELECT $1;     |   1
+ Planner      | Planner        |   2
+ ExecutorRun  | ExecutorRun    |   2
+ Result       | Result         |   3
+ Select query | SELECT $1;     |   1
+ Planner      | Planner        |   2
+ ExecutorRun  | ExecutorRun    |   2
+ Result       | Result         |   3
+(8 rows)
 
 CALL clean_spans();
 CALL reset_settings();

--- a/sql/transaction.sql
+++ b/sql/transaction.sql
@@ -6,6 +6,7 @@ SET pg_tracing.caller_sample_rate = 1.0;
 /*dddbs='postgres.db',traceparent='00-00000000000000000000000000000001-0000000000000001-01'*/ BEGIN; SELECT 1; COMMIT;
 
 SELECT span_type, span_operation, lvl FROM peek_ordered_spans where trace_id='00000000000000000000000000000001' AND span_type!='Commit';
+CALL clean_spans();
 
 -- Test with override of the trace context in the middle of a transaction
 /*dddbs='postgres.db',traceparent='00-00000000000000000000000000000002-0000000000000002-01'*/ BEGIN;
@@ -13,6 +14,32 @@ SELECT span_type, span_operation, lvl FROM peek_ordered_spans where trace_id='00
 
 SELECT span_type, span_operation, lvl FROM peek_ordered_spans where trace_id='00000000000000000000000000000002' AND span_type!='Commit';
 SELECT span_type, span_operation, lvl FROM peek_ordered_spans where trace_id='00000000000000000000000000000003';
+CALL clean_spans();
+
+-- Test with a 0 traceid in the middle of a transaction
+BEGIN;
+SELECT 1;
+/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000000-0000000000000001-01'*/ SELECT 2;
+SELECT 3;
+/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000000-0000000000000001-01'*/ SELECT 4;
+END;
+
+-- Only one trace id should have been generated
+SELECT count(distinct(trace_id)) = 1 FROM pg_tracing_peek_spans;
+SELECT span_type, span_operation, lvl FROM peek_ordered_spans;
+CALL clean_spans();
+
+-- Test with a 0 parent_id in the middle of a transaction
+BEGIN;
+SELECT 1;
+/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000000-0000000000000000-01'*/ SELECT 2;
+SELECT 3;
+/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000000-0000000000000000-01'*/ SELECT 4;
+END;
+
+-- Only one trace id and parent id should have been generated
+SELECT count(distinct(trace_id)) = 1, count(distinct(parent_id)) = 1 FROM peek_ordered_spans WHERE lvl=1;
+SELECT span_type, span_operation, lvl FROM peek_ordered_spans;
 
 CALL clean_spans();
 CALL reset_settings();

--- a/src/pg_tracing_otel.c
+++ b/src/pg_tracing_otel.c
@@ -12,7 +12,6 @@
 
 #include "pg_tracing.h"
 #include "postmaster/bgworker.h"
-#include "utils/timestamp.h"
 #include "postmaster/interrupt.h"
 #include "utils/memutils.h"
 #include "storage/latch.h"

--- a/src/version_compat.c
+++ b/src/version_compat.c
@@ -10,8 +10,6 @@
  */
 #include "postgres.h"
 
-#include "version_compat.h"
-
 #if PG_VERSION_NUM < 160000
 
 /*


### PR DESCRIPTION
When a statement is sampled within a transaction, save trace_id to be reused but don't set the whole transaction to be sampled.