### PR TITLE
Add transaction block span

### DIFF
--- a/expected/cursor.out
+++ b/expected/cursor.out
@@ -7,44 +7,52 @@ more than one row returned for \gset
 CLOSE c;
 COMMIT;
 -- First declare
--- +----------------------------------------+
--- | A: Declare (Utility)                   |
+-- +--------------------------------------------------------+
+-- | A: TransactionBlock...                                 |
+-- +----------------------------------------+---------------+
+-- | B: Declare (Utility)                   |
 -- ++------------------------------------+--+
---  | B: ProcessUtility                  |
+--  | C: ProcessUtility                  |
 --  +-+-------------------------------+--+
---    | C: Declare cursor... (Select) |
+--    | D: Declare cursor... (Select) |
 --    +-------------------------------+
---    | D: Planner   |
+--    | E: Planner   |
 --    +--------------+
 SELECT span_id AS span_a_id,
         get_epoch(span_start) as span_a_start,
         get_epoch(span_end) as span_a_end
 		from pg_tracing_peek_spans
         where trace_id='00000000000000000000000000000001' AND parent_id='0000000000000001'
-          AND span_operation='DECLARE c CURSOR FOR SELECT * from pg_tracing_test;' \gset
+          AND span_operation='TransactionBlock' \gset
 SELECT span_id AS span_b_id,
         get_epoch(span_start) as span_b_start,
         get_epoch(span_end) as span_b_end
 		from pg_tracing_peek_spans
-        where parent_id =:'span_a_id' and span_operation='ProcessUtility' \gset
+        where parent_id=:'span_a_id'
+          AND span_operation='DECLARE c CURSOR FOR SELECT * from pg_tracing_test;' \gset
 SELECT span_id AS span_c_id,
         get_epoch(span_start) as span_c_start,
         get_epoch(span_end) as span_c_end
 		from pg_tracing_peek_spans
-        where parent_id =:'span_b_id' and span_type='Select query' \gset
+        where parent_id =:'span_b_id' and span_operation='ProcessUtility' \gset
 SELECT span_id AS span_d_id,
         get_epoch(span_start) as span_d_start,
         get_epoch(span_end) as span_d_end
 		from pg_tracing_peek_spans
-        where parent_id =:'span_c_id' and span_operation='Planner' \gset
-SELECT :span_a_end >= MAX(v) as root_ends_last FROM UNNEST(ARRAY[:span_b_end, :span_c_end, :span_d_end]) as v;
+        where parent_id =:'span_c_id' and span_type='Select query' \gset
+SELECT span_id AS span_e_id,
+        get_epoch(span_start) as span_e_start,
+        get_epoch(span_end) as span_e_end
+		from pg_tracing_peek_spans
+        where parent_id =:'span_d_id' and span_operation='Planner' \gset
+SELECT :span_a_end >= MAX(v) as root_ends_last FROM UNNEST(ARRAY[:span_c_end, :span_d_end, :span_e_end]) as v;
  root_ends_last 
 ----------------
  t
 (1 row)
 
-SELECT :span_c_start >= :span_b_start as nested_declare_starts_after_parent,
-       :span_d_end <= :span_c_end as nested_planner_ends_before_parent;
+SELECT :span_d_start >= :span_c_start as nested_declare_starts_after_parent,
+       :span_e_end <= :span_d_end as nested_planner_ends_before_parent;
  nested_declare_starts_after_parent | nested_planner_ends_before_parent 
 ------------------------------------+-----------------------------------
  t                                  | t
@@ -60,35 +68,35 @@ SELECT :span_c_start >= :span_b_start as nested_declare_starts_after_parent,
 --    +------------------+------------+
 --    | D: ExecutorRun   |
 --    +------------------+
-SELECT span_id AS span_a_id,
-        get_epoch(span_start) as span_a_start,
-        get_epoch(span_end) as span_a_end
-		from pg_tracing_peek_spans
-        where trace_id='00000000000000000000000000000001' AND parent_id='0000000000000001'
-          AND span_operation='FETCH FORWARD 20 from c' \gset
 SELECT span_id AS span_b_id,
         get_epoch(span_start) as span_b_start,
         get_epoch(span_end) as span_b_end
 		from pg_tracing_peek_spans
-        where parent_id =:'span_a_id' and span_operation='ProcessUtility' \gset
+        where parent_id=:'span_a_id'
+          AND span_operation='FETCH FORWARD 20 from c' \gset
 SELECT span_id AS span_c_id,
         get_epoch(span_start) as span_c_start,
         get_epoch(span_end) as span_c_end
 		from pg_tracing_peek_spans
-        where parent_id =:'span_b_id' and span_type='Select query' \gset
+        where parent_id =:'span_b_id' and span_operation='ProcessUtility' \gset
 SELECT span_id AS span_d_id,
         get_epoch(span_start) as span_d_start,
         get_epoch(span_end) as span_d_end
 		from pg_tracing_peek_spans
-        where parent_id =:'span_c_id' and span_operation='ExecutorRun' \gset
-SELECT :span_a_end >= MAX(v) as root_ends_last FROM UNNEST(ARRAY[:span_b_end, :span_c_end, :span_d_end]) as v;
+        where parent_id =:'span_c_id' and span_type='Select query' \gset
+SELECT span_id AS span_e_id,
+        get_epoch(span_start) as span_e_start,
+        get_epoch(span_end) as span_e_end
+		from pg_tracing_peek_spans
+        where parent_id =:'span_d_id' and span_operation='ExecutorRun' \gset
+SELECT :span_b_end >= MAX(v) as root_ends_last FROM UNNEST(ARRAY[:span_c_end, :span_d_end, :span_e_end]) as v;
  root_ends_last 
 ----------------
  t
 (1 row)
 
-SELECT :span_c_start >= :span_b_start as nested_declare_starts_after_parent,
-       :span_d_end <= :span_c_end as nested_planner_ends_before_parent;
+SELECT :span_d_start >= :span_c_start as nested_declare_starts_after_parent,
+       :span_e_end <= :span_d_end as nested_planner_ends_before_parent;
  nested_declare_starts_after_parent | nested_planner_ends_before_parent 
 ------------------------------------+-----------------------------------
  t                                  | t
@@ -96,35 +104,35 @@ SELECT :span_c_start >= :span_b_start as nested_declare_starts_after_parent,
 
 -- Fetch Backward
 -- Same structure as fetch forward
-SELECT span_id AS span_a_id,
-        get_epoch(span_start) as span_a_start,
-        get_epoch(span_end) as span_a_end
-		from pg_tracing_peek_spans
-        where trace_id='00000000000000000000000000000001' AND parent_id='0000000000000001'
-          AND span_operation='FETCH BACKWARD 10 from c' \gset
 SELECT span_id AS span_b_id,
         get_epoch(span_start) as span_b_start,
         get_epoch(span_end) as span_b_end
 		from pg_tracing_peek_spans
-        where parent_id =:'span_a_id' and span_operation='ProcessUtility' \gset
+        where parent_id=:'span_a_id'
+          AND span_operation='FETCH BACKWARD 10 from c' \gset
 SELECT span_id AS span_c_id,
         get_epoch(span_start) as span_c_start,
         get_epoch(span_end) as span_c_end
 		from pg_tracing_peek_spans
-        where parent_id =:'span_b_id' and span_type='Select query' \gset
+        where parent_id =:'span_b_id' and span_operation='ProcessUtility' \gset
 SELECT span_id AS span_d_id,
         get_epoch(span_start) as span_d_start,
         get_epoch(span_end) as span_d_end
 		from pg_tracing_peek_spans
-        where parent_id =:'span_c_id' and span_operation='ExecutorRun' \gset
-SELECT :span_a_end >= MAX(v) as root_ends_last FROM UNNEST(ARRAY[:span_b_end, :span_c_end, :span_d_end]) as v;
+        where parent_id =:'span_c_id' and span_type='Select query' \gset
+SELECT span_id AS span_e_id,
+        get_epoch(span_start) as span_e_start,
+        get_epoch(span_end) as span_e_end
+		from pg_tracing_peek_spans
+        where parent_id =:'span_d_id' and span_operation='ExecutorRun' \gset
+SELECT :span_b_end >= MAX(v) as root_ends_last FROM UNNEST(ARRAY[:span_c_end, :span_d_end, :span_e_end]) as v;
  root_ends_last 
 ----------------
  t
 (1 row)
 
-SELECT :span_c_start >= :span_b_start as nested_declare_starts_after_parent,
-       :span_d_end <= :span_c_end as nested_planner_ends_before_parent;
+SELECT :span_d_start >= :span_c_start as nested_declare_starts_after_parent,
+       :span_e_end <= :span_d_end as nested_planner_ends_before_parent;
  nested_declare_starts_after_parent | nested_planner_ends_before_parent 
 ------------------------------------+-----------------------------------
  t                                  | t
@@ -132,28 +140,29 @@ SELECT :span_c_start >= :span_b_start as nested_declare_starts_after_parent,
 
 -- Check
 SELECT span_type, span_operation, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000001';
-   span_type    |                   span_operation                    | lvl 
-----------------+-----------------------------------------------------+-----
- Utility query  | BEGIN;                                              |   1
- ProcessUtility | ProcessUtility                                      |   2
- Utility query  | DECLARE c CURSOR FOR SELECT * from pg_tracing_test; |   1
- ProcessUtility | ProcessUtility                                      |   2
- Select query   | DECLARE c CURSOR FOR SELECT * from pg_tracing_test; |   3
- Planner        | Planner                                             |   4
- Utility query  | FETCH FORWARD 20 from c                             |   1
- ProcessUtility | ProcessUtility                                      |   2
- Select query   | DECLARE c CURSOR FOR SELECT * from pg_tracing_test; |   3
- ExecutorRun    | ExecutorRun                                         |   4
- Utility query  | FETCH BACKWARD 10 from c                            |   1
- ProcessUtility | ProcessUtility                                      |   2
- Select query   | DECLARE c CURSOR FOR SELECT * from pg_tracing_test; |   3
- ExecutorRun    | ExecutorRun                                         |   4
- Utility query  | CLOSE c;                                            |   1
- ProcessUtility | ProcessUtility                                      |   2
- Select query   | DECLARE c CURSOR FOR SELECT * from pg_tracing_test; |   3
- Utility query  | COMMIT;                                             |   1
- ProcessUtility | ProcessUtility                                      |   2
-(19 rows)
+    span_type     |                   span_operation                    | lvl 
+------------------+-----------------------------------------------------+-----
+ TransactionBlock | TransactionBlock                                    |   1
+ Utility query    | BEGIN;                                              |   2
+ ProcessUtility   | ProcessUtility                                      |   3
+ Utility query    | DECLARE c CURSOR FOR SELECT * from pg_tracing_test; |   2
+ ProcessUtility   | ProcessUtility                                      |   3
+ Select query     | DECLARE c CURSOR FOR SELECT * from pg_tracing_test; |   4
+ Planner          | Planner                                             |   5
+ Utility query    | FETCH FORWARD 20 from c                             |   2
+ ProcessUtility   | ProcessUtility                                      |   3
+ Select query     | DECLARE c CURSOR FOR SELECT * from pg_tracing_test; |   4
+ ExecutorRun      | ExecutorRun                                         |   5
+ Utility query    | FETCH BACKWARD 10 from c                            |   2
+ ProcessUtility   | ProcessUtility                                      |   3
+ Select query     | DECLARE c CURSOR FOR SELECT * from pg_tracing_test; |   4
+ ExecutorRun      | ExecutorRun                                         |   5
+ Utility query    | CLOSE c;                                            |   2
+ ProcessUtility   | ProcessUtility                                      |   3
+ Select query     | DECLARE c CURSOR FOR SELECT * from pg_tracing_test; |   4
+ Utility query    | COMMIT;                                             |   2
+ ProcessUtility   | ProcessUtility                                      |   3
+(20 rows)
 
 -- Clean created spans
 CALL clean_spans();

--- a/expected/extended.out
+++ b/expected/extended.out
@@ -64,29 +64,31 @@ SELECT count(distinct(trace_id)) = 1 FROM pg_tracing_peek_spans;
 (1 row)
 
 SELECT span_type, span_operation, parameters, lvl FROM peek_ordered_spans;
-   span_type    | span_operation | parameters | lvl 
-----------------+----------------+------------+-----
- Utility query  | BEGIN;         |            |   1
- ProcessUtility | ProcessUtility |            |   2
- Select query   | SELECT $1      | {1}        |   1
- Planner        | Planner        |            |   2
- ExecutorRun    | ExecutorRun    |            |   2
- Result         | Result         |            |   3
- Select query   | SELECT $1, $2  | {2,3}      |   1
- Planner        | Planner        |            |   2
- ExecutorRun    | ExecutorRun    |            |   2
- Result         | Result         |            |   3
- Utility query  | COMMIT;        |            |   1
- ProcessUtility | ProcessUtility |            |   2
- Utility query  | BEGIN          |            |   1
- ProcessUtility | ProcessUtility |            |   2
- Select query   | SELECT $1      | {1}        |   1
- Planner        | Planner        |            |   2
- ExecutorRun    | ExecutorRun    |            |   2
- Result         | Result         |            |   3
- Utility query  | COMMIT;        |            |   1
- ProcessUtility | ProcessUtility |            |   2
-(20 rows)
+    span_type     |  span_operation  | parameters | lvl 
+------------------+------------------+------------+-----
+ TransactionBlock | TransactionBlock |            |   1
+ Utility query    | BEGIN;           |            |   2
+ ProcessUtility   | ProcessUtility   |            |   3
+ Select query     | SELECT $1        | {1}        |   2
+ Planner          | Planner          |            |   3
+ ExecutorRun      | ExecutorRun      |            |   3
+ Result           | Result           |            |   4
+ Select query     | SELECT $1, $2    | {2,3}      |   2
+ Planner          | Planner          |            |   3
+ ExecutorRun      | ExecutorRun      |            |   3
+ Result           | Result           |            |   4
+ Utility query    | COMMIT;          |            |   2
+ ProcessUtility   | ProcessUtility   |            |   3
+ TransactionBlock | TransactionBlock |            |   1
+ Utility query    | BEGIN            |            |   2
+ ProcessUtility   | ProcessUtility   |            |   3
+ Select query     | SELECT $1        | {1}        |   2
+ Planner          | Planner          |            |   3
+ ExecutorRun      | ExecutorRun      |            |   3
+ Result           | Result           |            |   4
+ Utility query    | COMMIT;          |            |   2
+ ProcessUtility   | ProcessUtility   |            |   3
+(22 rows)
 
 CALL clean_spans();
 -- Mix extended protocol and simple protocol
@@ -118,25 +120,26 @@ SELECT count(distinct(trace_id)) = 1 FROM pg_tracing_peek_spans;
 (1 row)
 
 SELECT span_type, span_operation, parameters, lvl FROM peek_ordered_spans;
-   span_type    |   span_operation   | parameters | lvl 
-----------------+--------------------+------------+-----
- Utility query  | BEGIN;             |            |   1
- ProcessUtility | ProcessUtility     |            |   2
- Select query   | SELECT $1          | {1}        |   1
- Planner        | Planner            |            |   2
- ExecutorRun    | ExecutorRun        |            |   2
- Result         | Result             |            |   3
- Select query   | SELECT $1, $2, $3; | {5,6,7}    |   1
- Planner        | Planner            |            |   2
- ExecutorRun    | ExecutorRun        |            |   2
- Result         | Result             |            |   3
- Select query   | SELECT $1, $2      | {2,3}      |   1
- Planner        | Planner            |            |   2
- ExecutorRun    | ExecutorRun        |            |   2
- Result         | Result             |            |   3
- Utility query  | COMMIT;            |            |   1
- ProcessUtility | ProcessUtility     |            |   2
-(16 rows)
+    span_type     |   span_operation   | parameters | lvl 
+------------------+--------------------+------------+-----
+ TransactionBlock | TransactionBlock   |            |   1
+ Utility query    | BEGIN;             |            |   2
+ ProcessUtility   | ProcessUtility     |            |   3
+ Select query     | SELECT $1          | {1}        |   2
+ Planner          | Planner            |            |   3
+ ExecutorRun      | ExecutorRun        |            |   3
+ Result           | Result             |            |   4
+ Select query     | SELECT $1, $2, $3; | {5,6,7}    |   2
+ Planner          | Planner            |            |   3
+ ExecutorRun      | ExecutorRun        |            |   3
+ Result           | Result             |            |   4
+ Select query     | SELECT $1, $2      | {2,3}      |   2
+ Planner          | Planner            |            |   3
+ ExecutorRun      | ExecutorRun        |            |   3
+ Result           | Result             |            |   4
+ Utility query    | COMMIT;            |            |   2
+ ProcessUtility   | ProcessUtility     |            |   3
+(17 rows)
 
 CALL clean_spans();
 -- gdesc calls a single parse command then execute a query. Make sure we handle this case
@@ -182,25 +185,26 @@ SELECT $1, $2, $3 \bind 1 2 3 \g
 
 COMMIT;
 SELECT span_type, span_operation, parameters, lvl FROM peek_ordered_spans WHERE trace_id='00000000000000000000000000000001';
-   span_type    |  span_operation   | parameters | lvl 
-----------------+-------------------+------------+-----
- Utility query  | BEGIN;            |            |   1
- ProcessUtility | ProcessUtility    |            |   2
- Select query   | SELECT $1         | {1}        |   1
- Planner        | Planner           |            |   2
- ExecutorRun    | ExecutorRun       |            |   2
- Result         | Result            |            |   3
- Select query   | SELECT $1, $2     | {1,2}      |   1
- Planner        | Planner           |            |   2
- ExecutorRun    | ExecutorRun       |            |   2
- Result         | Result            |            |   3
- Select query   | SELECT $1, $2, $3 | {1,2,3}    |   1
- Planner        | Planner           |            |   2
- ExecutorRun    | ExecutorRun       |            |   2
- Result         | Result            |            |   3
- Utility query  | COMMIT;           |            |   1
- ProcessUtility | ProcessUtility    |            |   2
-(16 rows)
+    span_type     |  span_operation   | parameters | lvl 
+------------------+-------------------+------------+-----
+ TransactionBlock | TransactionBlock  |            |   1
+ Utility query    | BEGIN;            |            |   2
+ ProcessUtility   | ProcessUtility    |            |   3
+ Select query     | SELECT $1         | {1}        |   2
+ Planner          | Planner           |            |   3
+ ExecutorRun      | ExecutorRun       |            |   3
+ Result           | Result            |            |   4
+ Select query     | SELECT $1, $2     | {1,2}      |   2
+ Planner          | Planner           |            |   3
+ ExecutorRun      | ExecutorRun       |            |   3
+ Result           | Result            |            |   4
+ Select query     | SELECT $1, $2, $3 | {1,2,3}    |   2
+ Planner          | Planner           |            |   3
+ ExecutorRun      | ExecutorRun       |            |   3
+ Result           | Result            |            |   4
+ Utility query    | COMMIT;           |            |   2
+ ProcessUtility   | ProcessUtility    |            |   3
+(17 rows)
 
 -- Test tracing only individual statements with extended protocol
 BEGIN;
@@ -290,17 +294,18 @@ SELECT $1 \bind 1 \g
 
 COMMIT;
 SELECT span_type, span_operation, parameters, lvl FROM peek_ordered_spans WHERE trace_id='00000000000000000000000000000004';
-   span_type    | span_operation | parameters | lvl 
-----------------+----------------+------------+-----
- Utility query  | BEGIN          |            |   1
- ProcessUtility | ProcessUtility |            |   2
- Select query   | SELECT $1      | {1}        |   1
- Planner        | Planner        |            |   2
- ExecutorRun    | ExecutorRun    |            |   2
- Result         | Result         |            |   3
- Utility query  | COMMIT;        |            |   1
- ProcessUtility | ProcessUtility |            |   2
-(8 rows)
+    span_type     |  span_operation  | parameters | lvl 
+------------------+------------------+------------+-----
+ TransactionBlock | TransactionBlock |            |   1
+ Utility query    | BEGIN            |            |   2
+ ProcessUtility   | ProcessUtility   |            |   3
+ Select query     | SELECT $1        | {1}        |   2
+ Planner          | Planner          |            |   3
+ ExecutorRun      | ExecutorRun      |            |   3
+ Result           | Result           |            |   4
+ Utility query    | COMMIT;          |            |   2
+ ProcessUtility   | ProcessUtility   |            |   3
+(9 rows)
 
 -- Cleanup
 CALL clean_spans();

--- a/expected/guc.out
+++ b/expected/guc.out
@@ -32,27 +32,28 @@ SELECT 3;
 
 -- Check results for GUC propagation with simple and multiple statements
 select trace_id, span_operation, parameters, lvl from peek_ordered_spans;
-             trace_id             | span_operation | parameters | lvl 
-----------------------------------+----------------+------------+-----
- 00000000000000000000000000000004 | SELECT $1;     | {1}        |   1
- 00000000000000000000000000000004 | Planner        |            |   2
- 00000000000000000000000000000004 | ExecutorRun    |            |   2
- 00000000000000000000000000000004 | Result         |            |   3
- 00000000000000000000000000000005 | SELECT $1;     | {1}        |   1
- 00000000000000000000000000000005 | Planner        |            |   2
- 00000000000000000000000000000005 | ExecutorRun    |            |   2
- 00000000000000000000000000000005 | Result         |            |   3
- 00000000000000000000000000000005 | COMMIT;        |            |   1
- 00000000000000000000000000000005 | ProcessUtility |            |   2
- fffffffffffffffffffffffffffffff5 | SELECT $1;     | {2}        |   1
- fffffffffffffffffffffffffffffff5 | Planner        |            |   2
- fffffffffffffffffffffffffffffff5 | ExecutorRun    |            |   2
- fffffffffffffffffffffffffffffff5 | Result         |            |   3
- fffffffffffffffffffffffffffffff5 | SELECT $1;     | {3}        |   1
- fffffffffffffffffffffffffffffff5 | Planner        |            |   2
- fffffffffffffffffffffffffffffff5 | ExecutorRun    |            |   2
- fffffffffffffffffffffffffffffff5 | Result         |            |   3
-(18 rows)
+             trace_id             |  span_operation  | parameters | lvl 
+----------------------------------+------------------+------------+-----
+ 00000000000000000000000000000004 | SELECT $1;       | {1}        |   1
+ 00000000000000000000000000000004 | Planner          |            |   2
+ 00000000000000000000000000000004 | ExecutorRun      |            |   2
+ 00000000000000000000000000000004 | Result           |            |   3
+ 00000000000000000000000000000004 | TransactionBlock |            |   1
+ 00000000000000000000000000000005 | SELECT $1;       | {1}        |   2
+ 00000000000000000000000000000005 | Planner          |            |   3
+ 00000000000000000000000000000005 | ExecutorRun      |            |   3
+ 00000000000000000000000000000005 | Result           |            |   4
+ 00000000000000000000000000000005 | COMMIT;          |            |   2
+ 00000000000000000000000000000005 | ProcessUtility   |            |   3
+ fffffffffffffffffffffffffffffff5 | SELECT $1;       | {2}        |   1
+ fffffffffffffffffffffffffffffff5 | Planner          |            |   2
+ fffffffffffffffffffffffffffffff5 | ExecutorRun      |            |   2
+ fffffffffffffffffffffffffffffff5 | Result           |            |   3
+ fffffffffffffffffffffffffffffff5 | SELECT $1;       | {3}        |   1
+ fffffffffffffffffffffffffffffff5 | Planner          |            |   2
+ fffffffffffffffffffffffffffffff5 | ExecutorRun      |            |   2
+ fffffffffffffffffffffffffffffff5 | Result           |            |   3
+(19 rows)
 
 CALL clean_spans();
 -- Mix SQLCommenter and GUC propagation
@@ -135,3 +136,5 @@ select count(*) = 0 from peek_ordered_spans;
  t
 (1 row)
 
+-- Cleaning
+CALL clean_spans();

--- a/expected/setup.out
+++ b/expected/setup.out
@@ -30,5 +30,7 @@ $$ LANGUAGE plpgsql;
 -- Create test tables with data
 CALL reset_pg_tracing_test_table();
 NOTICE:  table "pg_tracing_test" does not exist, skipping
+-- Create test table to test modifications
+CREATE TABLE test_modifications (a int, b char(20));
 CREATE TABLE m AS SELECT i AS k, (i || ' v')::text v FROM generate_series(1, 16, 3) i;
 ALTER TABLE m ADD UNIQUE (k);

--- a/expected/subxact.out
+++ b/expected/subxact.out
@@ -18,34 +18,35 @@ COMMIT;
 select span_operation, parameters, subxact_count, lvl FROM peek_ordered_spans;
                           span_operation                          | parameters  | subxact_count | lvl 
 ------------------------------------------------------------------+-------------+---------------+-----
- BEGIN;                                                           |             |             0 |   1
- ProcessUtility                                                   |             |             0 |   2
- SAVEPOINT s1;                                                    |             |             0 |   1
- ProcessUtility                                                   |             |             0 |   2
- INSERT INTO pg_tracing_test VALUES(generate_series($1, $2), $3); | {1,2,'aaa'} |             0 |   1
- Planner                                                          |             |             0 |   2
- ExecutorRun                                                      |             |             0 |   2
- Insert on pg_tracing_test                                        |             |             1 |   3
- ProjectSet                                                       |             |             1 |   4
- Result                                                           |             |             1 |   5
- SAVEPOINT s2;                                                    |             |             1 |   1
- ProcessUtility                                                   |             |             1 |   2
- INSERT INTO pg_tracing_test VALUES(generate_series($1, $2), $3); | {1,2,'aaa'} |             1 |   1
- Planner                                                          |             |             1 |   2
- ExecutorRun                                                      |             |             1 |   2
- Insert on pg_tracing_test                                        |             |             2 |   3
- ProjectSet                                                       |             |             2 |   4
- Result                                                           |             |             2 |   5
- SAVEPOINT s3;                                                    |             |             2 |   1
- ProcessUtility                                                   |             |             2 |   2
- SELECT $1;                                                       | {1}         |             2 |   1
- Planner                                                          |             |             2 |   2
- ExecutorRun                                                      |             |             2 |   2
- Result                                                           |             |             2 |   3
- COMMIT;                                                          |             |             2 |   1
- ProcessUtility                                                   |             |             2 |   2
- TransactionCommit                                                |             |             2 |   1
-(27 rows)
+ TransactionBlock                                                 |             |             0 |   1
+ BEGIN;                                                           |             |             0 |   2
+ ProcessUtility                                                   |             |             0 |   3
+ SAVEPOINT s1;                                                    |             |             0 |   2
+ ProcessUtility                                                   |             |             0 |   3
+ INSERT INTO pg_tracing_test VALUES(generate_series($1, $2), $3); | {1,2,'aaa'} |             0 |   2
+ Planner                                                          |             |             0 |   3
+ ExecutorRun                                                      |             |             0 |   3
+ Insert on pg_tracing_test                                        |             |             1 |   4
+ ProjectSet                                                       |             |             1 |   5
+ Result                                                           |             |             1 |   6
+ SAVEPOINT s2;                                                    |             |             1 |   2
+ ProcessUtility                                                   |             |             1 |   3
+ INSERT INTO pg_tracing_test VALUES(generate_series($1, $2), $3); | {1,2,'aaa'} |             1 |   2
+ Planner                                                          |             |             1 |   3
+ ExecutorRun                                                      |             |             1 |   3
+ Insert on pg_tracing_test                                        |             |             2 |   4
+ ProjectSet                                                       |             |             2 |   5
+ Result                                                           |             |             2 |   6
+ SAVEPOINT s3;                                                    |             |             2 |   2
+ ProcessUtility                                                   |             |             2 |   3
+ SELECT $1;                                                       | {1}         |             2 |   2
+ Planner                                                          |             |             2 |   3
+ ExecutorRun                                                      |             |             2 |   3
+ Result                                                           |             |             2 |   4
+ COMMIT;                                                          |             |             2 |   2
+ ProcessUtility                                                   |             |             2 |   3
+ TransactionCommit                                                |             |             2 |   2
+(28 rows)
 
 -- Cleaning
 CALL clean_spans();

--- a/expected/transaction.out
+++ b/expected/transaction.out
@@ -9,17 +9,18 @@ SET pg_tracing.caller_sample_rate = 1.0;
 (1 row)
 
 SELECT span_type, span_operation, lvl FROM peek_ordered_spans where trace_id='00000000000000000000000000000001' AND span_type!='Commit';
-   span_type    | span_operation | lvl 
-----------------+----------------+-----
- Utility query  | BEGIN;         |   1
- ProcessUtility | ProcessUtility |   2
- Select query   | SELECT $1;     |   1
- Planner        | Planner        |   2
- ExecutorRun    | ExecutorRun    |   2
- Result         | Result         |   3
- Utility query  | COMMIT;        |   1
- ProcessUtility | ProcessUtility |   2
-(8 rows)
+    span_type     |  span_operation  | lvl 
+------------------+------------------+-----
+ TransactionBlock | TransactionBlock |   1
+ Utility query    | BEGIN;           |   2
+ ProcessUtility   | ProcessUtility   |   3
+ Select query     | SELECT $1;       |   2
+ Planner          | Planner          |   3
+ ExecutorRun      | ExecutorRun      |   3
+ Result           | Result           |   4
+ Utility query    | COMMIT;          |   2
+ ProcessUtility   | ProcessUtility   |   3
+(9 rows)
 
 CALL clean_spans();
 -- Test with override of the trace context in the middle of a transaction
@@ -31,21 +32,22 @@ CALL clean_spans();
 (1 row)
 
 SELECT span_type, span_operation, lvl FROM peek_ordered_spans where trace_id='00000000000000000000000000000002' AND span_type!='Commit';
-   span_type    | span_operation | lvl 
-----------------+----------------+-----
- Utility query  | BEGIN;         |   1
- ProcessUtility | ProcessUtility |   2
- Utility query  | COMMIT;        |   1
- ProcessUtility | ProcessUtility |   2
-(4 rows)
+    span_type     |  span_operation  | lvl 
+------------------+------------------+-----
+ TransactionBlock | TransactionBlock |   1
+ Utility query    | BEGIN;           |   2
+ ProcessUtility   | ProcessUtility   |   3
+ Utility query    | COMMIT;          |   2
+ ProcessUtility   | ProcessUtility   |   3
+(5 rows)
 
 SELECT span_type, span_operation, lvl FROM peek_ordered_spans where trace_id='00000000000000000000000000000003';
   span_type   | span_operation | lvl 
 --------------+----------------+-----
- Select query | SELECT $1;     |   1
- Planner      | Planner        |   2
- ExecutorRun  | ExecutorRun    |   2
- Result       | Result         |   3
+ Select query | SELECT $1;     |   2
+ Planner      | Planner        |   3
+ ExecutorRun  | ExecutorRun    |   3
+ Result       | Result         |   4
 (4 rows)
 
 CALL clean_spans();
@@ -143,6 +145,46 @@ SELECT span_type, span_operation, lvl FROM peek_ordered_spans;
  ExecutorRun  | ExecutorRun    |   2
  Result       | Result         |   3
 (8 rows)
+
+CALL clean_spans();
+-- Test modification within transaction block
+/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000001-0000000000000000-01'*/ BEGIN;
+INSERT INTO test_modifications(a, b) VALUES (1, 1);
+END;
+SELECT span_type, span_operation, lvl FROM peek_ordered_spans;
+     span_type     |                    span_operation                     | lvl 
+-------------------+-------------------------------------------------------+-----
+ TransactionBlock  | TransactionBlock                                      |   1
+ Utility query     | BEGIN;                                                |   2
+ ProcessUtility    | ProcessUtility                                        |   3
+ Insert query      | INSERT INTO test_modifications(a, b) VALUES ($1, $2); |   2
+ Planner           | Planner                                               |   3
+ ExecutorRun       | ExecutorRun                                           |   3
+ Insert            | Insert on test_modifications                          |   4
+ Result            | Result                                                |   5
+ Utility query     | END;                                                  |   2
+ ProcessUtility    | ProcessUtility                                        |   3
+ TransactionCommit | TransactionCommit                                     |   2
+(11 rows)
+
+SELECT span_id AS span_tx_block,
+        get_epoch(span_start) AS span_tx_block_start,
+        get_epoch(span_end) AS span_tx_block_end
+		FROM pg_tracing_peek_spans
+        WHERE trace_id='00000000000000000000000000000001' AND span_operation='TransactionBlock' \gset
+SELECT span_id AS span_commit,
+        get_epoch(span_start) as span_commit_start,
+        get_epoch(span_end) as span_commit_end
+		FROM pg_tracing_peek_spans
+        WHERE trace_id='00000000000000000000000000000001'
+            AND parent_id = :'span_tx_block'
+            AND span_operation='TransactionCommit' \gset
+-- Transaction block should end after TransactionCommit span
+SELECT :span_tx_block_end >= :span_commit_end;
+ ?column? 
+----------
+ t
+(1 row)
 
 CALL clean_spans();
 CALL reset_settings();

--- a/sql/cursor.sql
+++ b/sql/cursor.sql
@@ -6,14 +6,16 @@ CLOSE c;
 COMMIT;
 
 -- First declare
--- +----------------------------------------+
--- | A: Declare (Utility)                   |
+-- +--------------------------------------------------------+
+-- | A: TransactionBlock...                                 |
+-- +----------------------------------------+---------------+
+-- | B: Declare (Utility)                   |
 -- ++------------------------------------+--+
---  | B: ProcessUtility                  |
+--  | C: ProcessUtility                  |
 --  +-+-------------------------------+--+
---    | C: Declare cursor... (Select) |
+--    | D: Declare cursor... (Select) |
 --    +-------------------------------+
---    | D: Planner   |
+--    | E: Planner   |
 --    +--------------+
 
 SELECT span_id AS span_a_id,
@@ -21,26 +23,32 @@ SELECT span_id AS span_a_id,
         get_epoch(span_end) as span_a_end
 		from pg_tracing_peek_spans
         where trace_id='00000000000000000000000000000001' AND parent_id='0000000000000001'
-          AND span_operation='DECLARE c CURSOR FOR SELECT * from pg_tracing_test;' \gset
+          AND span_operation='TransactionBlock' \gset
 SELECT span_id AS span_b_id,
         get_epoch(span_start) as span_b_start,
         get_epoch(span_end) as span_b_end
 		from pg_tracing_peek_spans
-        where parent_id =:'span_a_id' and span_operation='ProcessUtility' \gset
+        where parent_id=:'span_a_id'
+          AND span_operation='DECLARE c CURSOR FOR SELECT * from pg_tracing_test;' \gset
 SELECT span_id AS span_c_id,
         get_epoch(span_start) as span_c_start,
         get_epoch(span_end) as span_c_end
 		from pg_tracing_peek_spans
-        where parent_id =:'span_b_id' and span_type='Select query' \gset
+        where parent_id =:'span_b_id' and span_operation='ProcessUtility' \gset
 SELECT span_id AS span_d_id,
         get_epoch(span_start) as span_d_start,
         get_epoch(span_end) as span_d_end
 		from pg_tracing_peek_spans
-        where parent_id =:'span_c_id' and span_operation='Planner' \gset
+        where parent_id =:'span_c_id' and span_type='Select query' \gset
+SELECT span_id AS span_e_id,
+        get_epoch(span_start) as span_e_start,
+        get_epoch(span_end) as span_e_end
+		from pg_tracing_peek_spans
+        where parent_id =:'span_d_id' and span_operation='Planner' \gset
 
-SELECT :span_a_end >= MAX(v) as root_ends_last FROM UNNEST(ARRAY[:span_b_end, :span_c_end, :span_d_end]) as v;
-SELECT :span_c_start >= :span_b_start as nested_declare_starts_after_parent,
-       :span_d_end <= :span_c_end as nested_planner_ends_before_parent;
+SELECT :span_a_end >= MAX(v) as root_ends_last FROM UNNEST(ARRAY[:span_c_end, :span_d_end, :span_e_end]) as v;
+SELECT :span_d_start >= :span_c_start as nested_declare_starts_after_parent,
+       :span_e_end <= :span_d_end as nested_planner_ends_before_parent;
 
 
 -- Fetch forward
@@ -54,60 +62,60 @@ SELECT :span_c_start >= :span_b_start as nested_declare_starts_after_parent,
 --    | D: ExecutorRun   |
 --    +------------------+
 
-SELECT span_id AS span_a_id,
-        get_epoch(span_start) as span_a_start,
-        get_epoch(span_end) as span_a_end
-		from pg_tracing_peek_spans
-        where trace_id='00000000000000000000000000000001' AND parent_id='0000000000000001'
-          AND span_operation='FETCH FORWARD 20 from c' \gset
 SELECT span_id AS span_b_id,
         get_epoch(span_start) as span_b_start,
         get_epoch(span_end) as span_b_end
 		from pg_tracing_peek_spans
-        where parent_id =:'span_a_id' and span_operation='ProcessUtility' \gset
+        where parent_id=:'span_a_id'
+          AND span_operation='FETCH FORWARD 20 from c' \gset
 SELECT span_id AS span_c_id,
         get_epoch(span_start) as span_c_start,
         get_epoch(span_end) as span_c_end
 		from pg_tracing_peek_spans
-        where parent_id =:'span_b_id' and span_type='Select query' \gset
+        where parent_id =:'span_b_id' and span_operation='ProcessUtility' \gset
 SELECT span_id AS span_d_id,
         get_epoch(span_start) as span_d_start,
         get_epoch(span_end) as span_d_end
 		from pg_tracing_peek_spans
-        where parent_id =:'span_c_id' and span_operation='ExecutorRun' \gset
+        where parent_id =:'span_c_id' and span_type='Select query' \gset
+SELECT span_id AS span_e_id,
+        get_epoch(span_start) as span_e_start,
+        get_epoch(span_end) as span_e_end
+		from pg_tracing_peek_spans
+        where parent_id =:'span_d_id' and span_operation='ExecutorRun' \gset
 
-SELECT :span_a_end >= MAX(v) as root_ends_last FROM UNNEST(ARRAY[:span_b_end, :span_c_end, :span_d_end]) as v;
-SELECT :span_c_start >= :span_b_start as nested_declare_starts_after_parent,
-       :span_d_end <= :span_c_end as nested_planner_ends_before_parent;
+SELECT :span_b_end >= MAX(v) as root_ends_last FROM UNNEST(ARRAY[:span_c_end, :span_d_end, :span_e_end]) as v;
+SELECT :span_d_start >= :span_c_start as nested_declare_starts_after_parent,
+       :span_e_end <= :span_d_end as nested_planner_ends_before_parent;
 
 -- Fetch Backward
 -- Same structure as fetch forward
 
-SELECT span_id AS span_a_id,
-        get_epoch(span_start) as span_a_start,
-        get_epoch(span_end) as span_a_end
-		from pg_tracing_peek_spans
-        where trace_id='00000000000000000000000000000001' AND parent_id='0000000000000001'
-          AND span_operation='FETCH BACKWARD 10 from c' \gset
 SELECT span_id AS span_b_id,
         get_epoch(span_start) as span_b_start,
         get_epoch(span_end) as span_b_end
 		from pg_tracing_peek_spans
-        where parent_id =:'span_a_id' and span_operation='ProcessUtility' \gset
+        where parent_id=:'span_a_id'
+          AND span_operation='FETCH BACKWARD 10 from c' \gset
 SELECT span_id AS span_c_id,
         get_epoch(span_start) as span_c_start,
         get_epoch(span_end) as span_c_end
 		from pg_tracing_peek_spans
-        where parent_id =:'span_b_id' and span_type='Select query' \gset
+        where parent_id =:'span_b_id' and span_operation='ProcessUtility' \gset
 SELECT span_id AS span_d_id,
         get_epoch(span_start) as span_d_start,
         get_epoch(span_end) as span_d_end
 		from pg_tracing_peek_spans
-        where parent_id =:'span_c_id' and span_operation='ExecutorRun' \gset
+        where parent_id =:'span_c_id' and span_type='Select query' \gset
+SELECT span_id AS span_e_id,
+        get_epoch(span_start) as span_e_start,
+        get_epoch(span_end) as span_e_end
+		from pg_tracing_peek_spans
+        where parent_id =:'span_d_id' and span_operation='ExecutorRun' \gset
 
-SELECT :span_a_end >= MAX(v) as root_ends_last FROM UNNEST(ARRAY[:span_b_end, :span_c_end, :span_d_end]) as v;
-SELECT :span_c_start >= :span_b_start as nested_declare_starts_after_parent,
-       :span_d_end <= :span_c_end as nested_planner_ends_before_parent;
+SELECT :span_b_end >= MAX(v) as root_ends_last FROM UNNEST(ARRAY[:span_c_end, :span_d_end, :span_e_end]) as v;
+SELECT :span_d_start >= :span_c_start as nested_declare_starts_after_parent,
+       :span_e_end <= :span_d_end as nested_planner_ends_before_parent;
 
 -- Check
 SELECT span_type, span_operation, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000001';

--- a/sql/guc.sql
+++ b/sql/guc.sql
@@ -43,3 +43,6 @@ SET pg_tracing.trace_context='dddbs=''postgres.db'',traceparent=''00-fffffffffff
 
 -- GUC errors and no GUC tracecontext should not generate spans
 select count(*) = 0 from peek_ordered_spans;
+
+-- Cleaning
+CALL clean_spans();

--- a/sql/setup.sql
+++ b/sql/setup.sql
@@ -34,5 +34,8 @@ $$ LANGUAGE plpgsql;
 -- Create test tables with data
 CALL reset_pg_tracing_test_table();
 
+-- Create test table to test modifications
+CREATE TABLE test_modifications (a int, b char(20));
+
 CREATE TABLE m AS SELECT i AS k, (i || ' v')::text v FROM generate_series(1, 16, 3) i;
 ALTER TABLE m ADD UNIQUE (k);

--- a/sql/transaction.sql
+++ b/sql/transaction.sql
@@ -40,6 +40,29 @@ END;
 -- Only one trace id and parent id should have been generated
 SELECT count(distinct(trace_id)) = 1, count(distinct(parent_id)) = 1 FROM peek_ordered_spans WHERE lvl=1;
 SELECT span_type, span_operation, lvl FROM peek_ordered_spans;
+CALL clean_spans();
+
+-- Test modification within transaction block
+/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000001-0000000000000000-01'*/ BEGIN;
+INSERT INTO test_modifications(a, b) VALUES (1, 1);
+END;
+SELECT span_type, span_operation, lvl FROM peek_ordered_spans;
+
+SELECT span_id AS span_tx_block,
+        get_epoch(span_start) AS span_tx_block_start,
+        get_epoch(span_end) AS span_tx_block_end
+		FROM pg_tracing_peek_spans
+        WHERE trace_id='00000000000000000000000000000001' AND span_operation='TransactionBlock' \gset
+SELECT span_id AS span_commit,
+        get_epoch(span_start) as span_commit_start,
+        get_epoch(span_end) as span_commit_end
+		FROM pg_tracing_peek_spans
+        WHERE trace_id='00000000000000000000000000000001'
+            AND parent_id = :'span_tx_block'
+            AND span_operation='TransactionCommit' \gset
+-- Transaction block should end after TransactionCommit span
+SELECT :span_tx_block_end >= :span_commit_end;
+
 
 CALL clean_spans();
 CALL reset_settings();

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -79,6 +79,7 @@ typedef enum SpanType
 	SPAN_EXECUTOR_RUN,			/* Wraps Executor run hook */
 	SPAN_EXECUTOR_FINISH,		/* Wraps Executor finish hook */
 	SPAN_TRANSACTION_COMMIT,	/* Wraps time between pre-commit and commit */
+	SPAN_TRANSACTION_BLOCK,		/* Represents an explicit transaction block */
 
 	/* Represents a node execution, generated from planstate */
 	SPAN_NODE,

--- a/src/pg_tracing_span.c
+++ b/src/pg_tracing_span.c
@@ -133,6 +133,8 @@ span_type_to_str(SpanType span_type)
 			return "ExecutorFinish";
 		case SPAN_TRANSACTION_COMMIT:
 			return "TransactionCommit";
+		case SPAN_TRANSACTION_BLOCK:
+			return "TransactionBlock";
 
 		case SPAN_NODE:
 			return "Node";


### PR DESCRIPTION
When a transaction is started with an explicit begin, create a dedicated transaction span that will be used as a parent for the whole transaction and ends with commit/abort.
