### PR TITLE
Work on a copy of spans before sending to otel collector

### DIFF
--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -330,8 +330,10 @@ typedef struct TracedPlanstate
 typedef struct JsonContext
 {
 	StringInfo	str;
+	int			num_spans;
 	int			span_type_count[NUM_SPAN_TYPE];
 	const		Span **span_type_to_spans[NUM_SPAN_TYPE];
+	const char *spans_str;
 }			JsonContext;
 
 typedef struct SpanContext
@@ -439,7 +441,10 @@ extern int
 extern void
 			marshal_spans_to_json(JsonContext * json_ctx);
 extern void
-			build_json_context(JsonContext * json_ctx, const pgTracingSpans * pgTracingSpans);
+			build_json_context(JsonContext * json_ctx,
+							   const pgTracingSpans * pgTracingSpans,
+							   const char *spans_str,
+							   int num_spans);
 
 /* pg_tracing_operation_hash.c */
 extern void

--- a/src/pg_tracing_json.c
+++ b/src/pg_tracing_json.c
@@ -271,11 +271,11 @@ append_span_attributes(const JsonContext * json_ctx, const Span * span)
 		append_attribute_int(str, "query.startup", span->startup, true, true);
 		if (span->parameter_offset != -1)
 			append_array_value_field(str, "query.parameters",
-									 shared_str + span->parameter_offset, span->num_parameters, true);
+									 json_ctx->spans_str + span->parameter_offset, span->num_parameters, true);
 
 		if (span->deparse_info_offset != -1)
 			append_attribute_string(str, "query.deparse_info",
-									shared_str + span->deparse_info_offset, true);
+									json_ctx->spans_str + span->deparse_info_offset, true);
 	}
 
 	if (span->sql_error_code > 0)
@@ -403,11 +403,13 @@ aggregate_span_by_type(JsonContext * json_ctx, const pgTracingSpans * pgTracingS
  * Prepare json context for json marshalling
  */
 void
-build_json_context(JsonContext * json_ctx, const pgTracingSpans * pgTracingSpans)
+build_json_context(JsonContext * json_ctx, const pgTracingSpans * pgTracingSpans, const char *spans_str, int num_spans)
 {
 	json_ctx->str = makeStringInfo();
 	memset(json_ctx->span_type_count, 0, sizeof(json_ctx->span_type_count));
 	memset(json_ctx->span_type_to_spans, 0, sizeof(json_ctx->span_type_to_spans));
+	json_ctx->spans_str = spans_str;
+	json_ctx->num_spans = num_spans;
 
 	aggregate_span_by_type(json_ctx, pgTracingSpans);
 }

--- a/src/pg_tracing_sql_functions.c
+++ b/src/pg_tracing_sql_functions.c
@@ -237,7 +237,7 @@ pg_tracing_json_spans(PG_FUNCTION_ARGS)
 	cleanup_tracing();
 
 	LWLockAcquire(pg_tracing_shared_state->lock, LW_SHARED);
-	build_json_context(&json_ctx, shared_spans);
+	build_json_context(&json_ctx, shared_spans, shared_str, shared_spans->end);
 	marshal_spans_to_json(&json_ctx);
 	LWLockRelease(pg_tracing_shared_state->lock);
 


### PR DESCRIPTION
To avoid locking spans with an exclusive lock while sending the json payload to the collector, we create a copy of both spans and spans_str and immediately release the lock.

From the copy, we marshal the json payload to be sent and attempt to send it. We keep this payload until send is successful.
