### PR TITLE
Handle 0 query id and tune tx_block spans

### DIFF
--- a/expected/extended.out
+++ b/expected/extended.out
@@ -228,21 +228,22 @@ BEGIN;
 
 COMMIT;
 SELECT span_type, span_operation, parameters, lvl FROM peek_ordered_spans WHERE trace_id='00000000000000000000000000000002';
-  span_type   |  span_operation   | parameters | lvl 
---------------+-------------------+------------+-----
- Select query | SELECT $1         | {1}        |   1
- Planner      | Planner           |            |   2
- ExecutorRun  | ExecutorRun       |            |   2
- Result       | Result            |            |   3
- Select query | SELECT $1, $2     | {1,2}      |   1
- Planner      | Planner           |            |   2
- ExecutorRun  | ExecutorRun       |            |   2
- Result       | Result            |            |   3
- Select query | SELECT $1, $2, $3 | {1,2,3}    |   1
- Planner      | Planner           |            |   2
- ExecutorRun  | ExecutorRun       |            |   2
- Result       | Result            |            |   3
-(12 rows)
+    span_type     |  span_operation   | parameters | lvl 
+------------------+-------------------+------------+-----
+ TransactionBlock | TransactionBlock  |            |   1
+ Select query     | SELECT $1         | {1}        |   2
+ Planner          | Planner           |            |   3
+ ExecutorRun      | ExecutorRun       |            |   3
+ Result           | Result            |            |   4
+ Select query     | SELECT $1, $2     | {1,2}      |   2
+ Planner          | Planner           |            |   3
+ ExecutorRun      | ExecutorRun       |            |   3
+ Result           | Result            |            |   4
+ Select query     | SELECT $1, $2, $3 | {1,2,3}    |   2
+ Planner          | Planner           |            |   3
+ ExecutorRun      | ExecutorRun       |            |   3
+ Result           | Result            |            |   4
+(13 rows)
 
 -- Test tracing only subset of individual statements with extended protocol
 BEGIN;
@@ -272,17 +273,18 @@ SELECT $1 \bind 1 \g
 
 COMMIT;
 SELECT span_type, span_operation, parameters, lvl FROM peek_ordered_spans WHERE trace_id='00000000000000000000000000000003';
-  span_type   |  span_operation   | parameters | lvl 
---------------+-------------------+------------+-----
- Select query | SELECT $1         | {1}        |   1
- Planner      | Planner           |            |   2
- ExecutorRun  | ExecutorRun       |            |   2
- Result       | Result            |            |   3
- Select query | SELECT $1, $2, $3 | {1,2,3}    |   1
- Planner      | Planner           |            |   2
- ExecutorRun  | ExecutorRun       |            |   2
- Result       | Result            |            |   3
-(8 rows)
+    span_type     |  span_operation   | parameters | lvl 
+------------------+-------------------+------------+-----
+ TransactionBlock | TransactionBlock  |            |   1
+ Select query     | SELECT $1         | {1}        |   2
+ Planner          | Planner           |            |   3
+ ExecutorRun      | ExecutorRun       |            |   3
+ Result           | Result            |            |   4
+ Select query     | SELECT $1, $2, $3 | {1,2,3}    |   2
+ Planner          | Planner           |            |   3
+ ExecutorRun      | ExecutorRun       |            |   3
+ Result           | Result            |            |   4
+(9 rows)
 
 -- Test tracing the whole transaction with extended protocol with BEGIN sent through extended protocol
 /*dddbs='postgres.db',traceparent='00-00000000000000000000000000000004-0000000000000004-01'*/ BEGIN \bind \g

--- a/expected/parallel.out
+++ b/expected/parallel.out
@@ -32,8 +32,10 @@ set local pg_tracing.trace_parallel_workers = false;
 (1 row)
 
 commit;
--- Get root top span id
-SELECT span_id as root_span_id from pg_tracing_peek_spans where span_type='Select query' and trace_id='00000000000000000000000000000001' and parent_id='0000000000000001' \gset
+-- get tx block
+select span_id as tx_block_id from pg_tracing_peek_spans where span_type='TransactionBlock' and trace_id='00000000000000000000000000000001' and parent_id='0000000000000001' \gset
+-- get root top span id
+select span_id as root_span_id from pg_tracing_peek_spans where span_type='Select query' and trace_id='00000000000000000000000000000001' and parent_id=:'tx_block_id' \gset
 -- Get executor top span id
 SELECT span_id as executor_span_id from pg_tracing_peek_spans where span_operation='ExecutorRun' and trace_id='00000000000000000000000000000001' and parent_id=:'root_span_id' \gset
 -- Check the select spans that are attached to the root top span

--- a/expected/transaction.out
+++ b/expected/transaction.out
@@ -187,4 +187,39 @@ SELECT :span_tx_block_end >= :span_commit_end;
 (1 row)
 
 CALL clean_spans();
+-- Test with transaction block created with sample rate
+SET pg_tracing.sample_rate = 1.0;
+BEGIN;
+/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000001-0000000000000001-01'*/ SELECT 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000001-0000000000000002-01'*/ SELECT 2;
+ ?column? 
+----------
+        2
+(1 row)
+
+COMMIT;
+SELECT span_type, span_operation, lvl FROM peek_ordered_spans where trace_id='00000000000000000000000000000001';
+    span_type     |  span_operation  | lvl 
+------------------+------------------+-----
+ TransactionBlock | TransactionBlock |   1
+ Utility query    | BEGIN;           |   2
+ ProcessUtility   | ProcessUtility   |   3
+ Select query     | SELECT $1;       |   2
+ Planner          | Planner          |   3
+ ExecutorRun      | ExecutorRun      |   3
+ Result           | Result           |   4
+ Select query     | SELECT $1;       |   2
+ Planner          | Planner          |   3
+ ExecutorRun      | ExecutorRun      |   3
+ Result           | Result           |   4
+ Utility query    | COMMIT;          |   2
+ ProcessUtility   | ProcessUtility   |   3
+(13 rows)
+
 CALL reset_settings();
+CALL clean_spans();

--- a/expected/transaction.out
+++ b/expected/transaction.out
@@ -86,17 +86,18 @@ SELECT count(distinct(trace_id)) = 1 FROM pg_tracing_peek_spans;
 (1 row)
 
 SELECT span_type, span_operation, lvl FROM peek_ordered_spans;
-  span_type   | span_operation | lvl 
---------------+----------------+-----
- Select query | SELECT $1;     |   1
- Planner      | Planner        |   2
- ExecutorRun  | ExecutorRun    |   2
- Result       | Result         |   3
- Select query | SELECT $1;     |   1
- Planner      | Planner        |   2
- ExecutorRun  | ExecutorRun    |   2
- Result       | Result         |   3
-(8 rows)
+    span_type     |  span_operation  | lvl 
+------------------+------------------+-----
+ TransactionBlock | TransactionBlock |   1
+ Select query     | SELECT $1;       |   2
+ Planner          | Planner          |   3
+ ExecutorRun      | ExecutorRun      |   3
+ Result           | Result           |   4
+ Select query     | SELECT $1;       |   2
+ Planner          | Planner          |   3
+ ExecutorRun      | ExecutorRun      |   3
+ Result           | Result           |   4
+(9 rows)
 
 CALL clean_spans();
 -- Test with a 0 parent_id in the middle of a transaction
@@ -134,17 +135,18 @@ SELECT count(distinct(trace_id)) = 1, count(distinct(parent_id)) = 1 FROM peek_o
 (1 row)
 
 SELECT span_type, span_operation, lvl FROM peek_ordered_spans;
-  span_type   | span_operation | lvl 
---------------+----------------+-----
- Select query | SELECT $1;     |   1
- Planner      | Planner        |   2
- ExecutorRun  | ExecutorRun    |   2
- Result       | Result         |   3
- Select query | SELECT $1;     |   1
- Planner      | Planner        |   2
- ExecutorRun  | ExecutorRun    |   2
- Result       | Result         |   3
-(8 rows)
+    span_type     |  span_operation  | lvl 
+------------------+------------------+-----
+ TransactionBlock | TransactionBlock |   1
+ Select query     | SELECT $1;       |   2
+ Planner          | Planner          |   3
+ ExecutorRun      | ExecutorRun      |   3
+ Result           | Result           |   4
+ Select query     | SELECT $1;       |   2
+ Planner          | Planner          |   3
+ ExecutorRun      | ExecutorRun      |   3
+ Result           | Result           |   4
+(9 rows)
 
 CALL clean_spans();
 -- Test modification within transaction block

--- a/sql/parallel.sql
+++ b/sql/parallel.sql
@@ -15,8 +15,10 @@ set local pg_tracing.trace_parallel_workers = false;
 /*dddbs='postgres.db',traceparent='00-00000000000000000000000000000004-0000000000000004-01'*/ select 4 from pg_class limit 1;
 commit;
 
--- Get root top span id
-SELECT span_id as root_span_id from pg_tracing_peek_spans where span_type='Select query' and trace_id='00000000000000000000000000000001' and parent_id='0000000000000001' \gset
+-- get tx block
+select span_id as tx_block_id from pg_tracing_peek_spans where span_type='TransactionBlock' and trace_id='00000000000000000000000000000001' and parent_id='0000000000000001' \gset
+-- get root top span id
+select span_id as root_span_id from pg_tracing_peek_spans where span_type='Select query' and trace_id='00000000000000000000000000000001' and parent_id=:'tx_block_id' \gset
 -- Get executor top span id
 SELECT span_id as executor_span_id from pg_tracing_peek_spans where span_operation='ExecutorRun' and trace_id='00000000000000000000000000000001' and parent_id=:'root_span_id' \gset
 

--- a/src/pg_tracing.c
+++ b/src/pg_tracing.c
@@ -1012,9 +1012,6 @@ process_query_desc(const Traceparent * traceparent, const QueryDesc *queryDesc,
 		TimestampTz parent_start = per_level_infos[nested_level].executor_start;
 		uint64		query_id = queryDesc->plannedstmt->queryId;
 
-		if (query_id == 0)
-			query_id = current_query_id;
-
 		process_planstate(traceparent, queryDesc, sql_error_code,
 						  pg_tracing_deparse_plan, parent_id, query_id,
 						  parent_start, parent_end,
@@ -1421,9 +1418,6 @@ initialise_span_context(SpanContext * span_context,
 		span_context->query_id = pstmt->queryId;
 	else
 		span_context->query_id = query->queryId;
-
-	if (span_context->query_id == 0)
-		span_context->query_id = current_query_id;
 }
 
 /*
@@ -2097,9 +2091,6 @@ pg_tracing_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 
 		process_utility_span->node_counters.rows = qc->nprocessed;
 	}
-
-	if (nested_level == 0)
-		current_query_id = pstmt->queryId;
 
 	/* End ProcessUtility span and store it */
 	pop_active_span(&span_end_time);

--- a/src/pg_tracing.c
+++ b/src/pg_tracing.c
@@ -1055,6 +1055,8 @@ set_trace_id(Traceparent * traceparent)
 
 	traceparent->trace_id.traceid_left = pg_prng_int64(&pg_global_prng_state);
 	traceparent->trace_id.traceid_right = pg_prng_int64(&pg_global_prng_state);
+	/* Tag it as generated */
+	traceparent->generated = true;
 
 	if (new_lxid)
 

--- a/src/pg_tracing.c
+++ b/src/pg_tracing.c
@@ -1745,6 +1745,13 @@ pg_tracing_ExecutorRun(QueryDesc *queryDesc, ScanDirection direction, uint64 cou
 		return;
 	}
 
+	/*
+	 * Temporary workaround around a known issue where query id is not
+	 * propagated with extended protocol. See
+	 * https://www.postgresql.org/message-id/flat/CA+427g8DiW3aZ6pOpVgkPbqK97ouBdf18VLiHFesea2jUk3XoQ@mail.gmail.com
+	 */
+	pgstat_report_query_id(queryDesc->plannedstmt->queryId, false);
+
 	/* ExecutorRun is sampled */
 	initialize_trace_level();
 	initialise_span_context(&span_context, traceparent,
@@ -2013,6 +2020,13 @@ pg_tracing_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 	}
 
 	/* Statement is sampled */
+
+	/*
+	 * Temporary workaround around a known issue where query id is not
+	 * propagated with extended protocol. See
+	 * https://www.postgresql.org/message-id/flat/CA+427g8DiW3aZ6pOpVgkPbqK97ouBdf18VLiHFesea2jUk3XoQ@mail.gmail.com
+	 */
+	pgstat_report_query_id(pstmt->queryId, false);
 
 	/*
 	 * Keep track if we're in a declare cursor as we want to disable query

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -399,6 +399,7 @@ extern const char *get_span_type(const Span * span);
 extern const char *get_operation_name(const Span * span);
 extern void adjust_file_offset(Span * span, Size file_position);
 extern bool traceid_zero(TraceId trace_id);
+extern bool traceid_equal(TraceId trace_id_1, TraceId trace_id_2);
 extern const char *span_type_to_str(SpanType span_type);
 
 

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -281,6 +281,7 @@ typedef struct Traceparent
 	TraceId		trace_id;		/* Id of the trace */
 	uint64		parent_id;		/* Span id of the parent */
 	int			sampled;		/* Is current statement sampled? */
+	bool		generated;		/* Was it generated? */
 }			Traceparent;
 
 /*

--- a/src/pg_tracing_span.c
+++ b/src/pg_tracing_span.c
@@ -54,7 +54,6 @@ begin_span(TraceId trace_id, Span * span, SpanType type,
 	span->database_id = MyDatabaseId;
 	span->user_id = GetUserId();
 	span->subxact_count = MyProc->subxidStatus.count;
-	Assert(query_id > 0);
 	span->query_id = query_id;
 	memset(&span->node_counters, 0, sizeof(NodeCounters));
 	memset(&span->plan_counters, 0, sizeof(PlanCounters));
@@ -342,4 +341,14 @@ bool
 traceid_zero(TraceId trace_id)
 {
 	return trace_id.traceid_left == 0 && trace_id.traceid_right == 0;
+}
+
+/*
+* Returns true if trace ids are equals
+*/
+bool
+traceid_equal(TraceId trace_id_1, TraceId trace_id_2)
+{
+	return trace_id_1.traceid_left == trace_id_2.traceid_left &&
+		trace_id_1.traceid_right == trace_id_2.traceid_right;
 }

--- a/src/pg_tracing_sql_functions.c
+++ b/src/pg_tracing_sql_functions.c
@@ -294,7 +294,7 @@ pg_tracing_spans(PG_FUNCTION_ARGS)
 		drop_all_spans_locked();
 	LWLockRelease(pg_tracing_shared_state->lock);
 
-	return (Datum) 0;
+	PG_RETURN_VOID();
 }
 
 /*


### PR DESCRIPTION
Query id can be set to 0 despite compute_query_id being set. Fallback to store the query string without using the hashmap in this case.

Also modify the creation of the tx_block spans: If we are in a middle of a tx_block and there's no existing tx_block span, create one. 