### PR TITLE
Handle max parameter size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,11 +27,11 @@ OBJS = \
 	src/pg_tracing_strinfo.o \
 	src/version_compat.o
 
-REGRESSCHECKS = setup utility select insert trigger cursor json transaction
+REGRESSCHECKS = setup utility select parameters insert trigger cursor json transaction
 ifeq ($(PG_VERSION),15)
 REGRESSCHECKS += trigger_15
 else
-REGRESSCHECKS += extended trigger_16
+REGRESSCHECKS += extended trigger_16 parameters_16
 endif
 REGRESSCHECKS += sample planstate planstate_bitmap planstate_hash \
 				 planstate_projectset planstate_subplans planstate_union \

--- a/doc/pg_tracing.md
+++ b/doc/pg_tracing.md
@@ -189,10 +189,6 @@ Controls the fraction of statements that generate spans. Statements with traceco
 
 Controls the fraction of statements with SQLCommenter tracecontext and an enabled sampled flag that will generate spans. The default value is 1.
 
-### pg_tracing.export_parameters (boolean)
-
-Controls whether the query's parameters should be exported in spans metadata. The default value is `on`.
-
 ### pg_tracing.otel_endpoint (string)
 
 URL of the otel collector to send spans to. Example: 'http://127.0.0.1:4318/v1/traces'. This parameter can only be set at server start. The default value is NULL.

--- a/expected/parameters.out
+++ b/expected/parameters.out
@@ -1,0 +1,167 @@
+-- Check that parameters are not exported when disabled
+SET pg_tracing.max_parameter_size=0;
+/*traceparent='00-00000000000000000000000000000001-0000000000000001-01'*/ select 1, 2, 3;
+ ?column? | ?column? | ?column? 
+----------+----------+----------
+        1 |        2 |        3
+(1 row)
+
+SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000001';
+   span_operation   | parameters | lvl 
+--------------------+------------+-----
+ select $1, $2, $3; |            |   1
+ Planner            |            |   2
+ ExecutorRun        |            |   2
+ Result             |            |   3
+(4 rows)
+
+-- Saturate the parameter buffer
+SET pg_tracing.max_parameter_size=1;
+/*traceparent='00-00000000000000000000000000000002-0000000000000002-01'*/ select 1, 2, 3;
+ ?column? | ?column? | ?column? 
+----------+----------+----------
+        1 |        2 |        3
+(1 row)
+
+SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000002';
+   span_operation   | parameters  | lvl 
+--------------------+-------------+-----
+ select $1, $2, $3; | {1,...,...} |   1
+ Planner            |             |   2
+ ExecutorRun        |             |   2
+ Result             |             |   3
+(4 rows)
+
+SET pg_tracing.max_parameter_size=2;
+/*traceparent='00-00000000000000000000000000000003-0000000000000003-01'*/ select 1, 2, 3;
+ ?column? | ?column? | ?column? 
+----------+----------+----------
+        1 |        2 |        3
+(1 row)
+
+SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000003';
+   span_operation   | parameters  | lvl 
+--------------------+-------------+-----
+ select $1, $2, $3; | {1,...,...} |   1
+ Planner            |             |   2
+ ExecutorRun        |             |   2
+ Result             |             |   3
+(4 rows)
+
+SET pg_tracing.max_parameter_size=3;
+/*traceparent='00-00000000000000000000000000000004-0000000000000004-01'*/ select 1, 2, 3;
+ ?column? | ?column? | ?column? 
+----------+----------+----------
+        1 |        2 |        3
+(1 row)
+
+SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000004';
+   span_operation   | parameters | lvl 
+--------------------+------------+-----
+ select $1, $2, $3; | {1,2,...}  |   1
+ Planner            |            |   2
+ ExecutorRun        |            |   2
+ Result             |            |   3
+(4 rows)
+
+SET pg_tracing.max_parameter_size=4;
+/*traceparent='00-00000000000000000000000000000005-0000000000000005-01'*/ select 1, 2, 3;
+ ?column? | ?column? | ?column? 
+----------+----------+----------
+        1 |        2 |        3
+(1 row)
+
+SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000005';
+   span_operation   | parameters | lvl 
+--------------------+------------+-----
+ select $1, $2, $3; | {1,2,...}  |   1
+ Planner            |            |   2
+ ExecutorRun        |            |   2
+ Result             |            |   3
+(4 rows)
+
+SET pg_tracing.max_parameter_size=5;
+/*traceparent='00-00000000000000000000000000000006-0000000000000006-01'*/ select 1, 2, 3;
+ ?column? | ?column? | ?column? 
+----------+----------+----------
+        1 |        2 |        3
+(1 row)
+
+SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000006';
+   span_operation   | parameters | lvl 
+--------------------+------------+-----
+ select $1, $2, $3; | {1,2,3}    |   1
+ Planner            |            |   2
+ ExecutorRun        |            |   2
+ Result             |            |   3
+(4 rows)
+
+CALL clean_spans();
+-- Test truncated string
+SET pg_tracing.max_parameter_size=2;
+/*traceparent='00-00000000000000000000000000000001-0000000000000001-01'*/ select 'testtruncatedstring';
+      ?column?       
+---------------------
+ testtruncatedstring
+(1 row)
+
+SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000001';
+ span_operation | parameters | lvl 
+----------------+------------+-----
+ select $1;     | {'t...}    |   1
+ Planner        |            |   2
+ ExecutorRun    |            |   2
+ Result         |            |   3
+(4 rows)
+
+SET pg_tracing.max_parameter_size=19;
+/*traceparent='00-00000000000000000000000000000002-0000000000000002-01'*/ select 'testtruncatedstring';
+      ?column?       
+---------------------
+ testtruncatedstring
+(1 row)
+
+SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000002';
+ span_operation |        parameters        | lvl 
+----------------+--------------------------+-----
+ select $1;     | {'testtruncatedstrin...} |   1
+ Planner        |                          |   2
+ ExecutorRun    |                          |   2
+ Result         |                          |   3
+(4 rows)
+
+SET pg_tracing.max_parameter_size=20;
+/*traceparent='00-00000000000000000000000000000003-0000000000000003-01'*/ select 'testtruncatedstring';
+      ?column?       
+---------------------
+ testtruncatedstring
+(1 row)
+
+SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000003';
+ span_operation |        parameters         | lvl 
+----------------+---------------------------+-----
+ select $1;     | {'testtruncatedstring...} |   1
+ Planner        |                           |   2
+ ExecutorRun    |                           |   2
+ Result         |                           |   3
+(4 rows)
+
+SET pg_tracing.max_parameter_size=21;
+/*traceparent='00-00000000000000000000000000000004-0000000000000004-01'*/ select 'testtruncatedstring';
+      ?column?       
+---------------------
+ testtruncatedstring
+(1 row)
+
+SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000004';
+ span_operation |       parameters        | lvl 
+----------------+-------------------------+-----
+ select $1;     | {'testtruncatedstring'} |   1
+ Planner        |                         |   2
+ ExecutorRun    |                         |   2
+ Result         |                         |   3
+(4 rows)
+
+-- Cleanup
+CALL clean_spans();
+CALL reset_settings();

--- a/expected/parameters_16.out
+++ b/expected/parameters_16.out
@@ -1,0 +1,52 @@
+-- Saturate the parameter buffer with extended protocol
+SET pg_tracing.max_parameter_size=1;
+/*traceparent='00-00000000000000000000000000000001-0000000000000001-01'*/ select $1, $2, $3 \bind 1 2 3 \g
+ ?column? | ?column? | ?column? 
+----------+----------+----------
+ 1        | 2        | 3
+(1 row)
+
+SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000001';
+  span_operation   | parameters  | lvl 
+-------------------+-------------+-----
+ select $1, $2, $3 | {1,...,...} |   1
+ Planner           |             |   2
+ ExecutorRun       |             |   2
+ Result            |             |   3
+(4 rows)
+
+SET pg_tracing.max_parameter_size=2;
+/*traceparent='00-00000000000000000000000000000002-0000000000000002-01'*/ select $1, $2, $3 \bind 1 2 3 \g
+ ?column? | ?column? | ?column? 
+----------+----------+----------
+ 1        | 2        | 3
+(1 row)
+
+SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000002';
+  span_operation   | parameters  | lvl 
+-------------------+-------------+-----
+ select $1, $2, $3 | {1,...,...} |   1
+ Planner           |             |   2
+ ExecutorRun       |             |   2
+ Result            |             |   3
+(4 rows)
+
+SET pg_tracing.max_parameter_size=3;
+/*traceparent='00-00000000000000000000000000000003-0000000000000003-01'*/ select $1, $2, $3 \bind 1 2 3 \g
+ ?column? | ?column? | ?column? 
+----------+----------+----------
+ 1        | 2        | 3
+(1 row)
+
+SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000003';
+  span_operation   | parameters | lvl 
+-------------------+------------+-----
+ select $1, $2, $3 | {1,2,...}  |   1
+ Planner           |            |   2
+ ExecutorRun       |            |   2
+ Result            |            |   3
+(4 rows)
+
+-- Cleanup
+CALL clean_spans();
+CALL reset_settings();

--- a/expected/select.out
+++ b/expected/select.out
@@ -172,24 +172,6 @@ SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='0
  Result         |            |   3
 (4 rows)
 
--- Check that parameters are not exported when disabled
-SET pg_tracing.export_parameters=false;
-/*dddbs='postgres.db',traceparent='00-0000000000000000000000000000000d-000000000000000d-01'*/ select 1, 2, 3;
- ?column? | ?column? | ?column? 
-----------+----------+----------
-        1 |        2 |        3
-(1 row)
-
-SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='0000000000000000000000000000000d';
-   span_operation   | parameters | lvl 
---------------------+------------+-----
- select $1, $2, $3; |            |   1
- Planner            |            |   2
- ExecutorRun        |            |   2
- Result             |            |   3
-(4 rows)
-
-SET pg_tracing.export_parameters=true;
 -- Check multi statement query
 CALL clean_spans();
 SET pg_tracing.sample_rate = 1.0;

--- a/expected/setup.out
+++ b/expected/setup.out
@@ -16,6 +16,7 @@ AS $$
     SET pg_tracing.sample_rate TO DEFAULT;
     SET pg_tracing.caller_sample_rate TO DEFAULT;
     SET pg_tracing.track_utility TO DEFAULT;
+    SET pg_tracing.max_parameter_size TO DEFAULT;
 $$;
 CREATE OR REPLACE PROCEDURE reset_pg_tracing_test_table() AS $$
 BEGIN

--- a/sql/parameters.sql
+++ b/sql/parameters.sql
@@ -1,0 +1,47 @@
+-- Check that parameters are not exported when disabled
+SET pg_tracing.max_parameter_size=0;
+/*traceparent='00-00000000000000000000000000000001-0000000000000001-01'*/ select 1, 2, 3;
+SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000001';
+
+-- Saturate the parameter buffer
+SET pg_tracing.max_parameter_size=1;
+/*traceparent='00-00000000000000000000000000000002-0000000000000002-01'*/ select 1, 2, 3;
+SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000002';
+
+SET pg_tracing.max_parameter_size=2;
+/*traceparent='00-00000000000000000000000000000003-0000000000000003-01'*/ select 1, 2, 3;
+SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000003';
+
+SET pg_tracing.max_parameter_size=3;
+/*traceparent='00-00000000000000000000000000000004-0000000000000004-01'*/ select 1, 2, 3;
+SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000004';
+
+SET pg_tracing.max_parameter_size=4;
+/*traceparent='00-00000000000000000000000000000005-0000000000000005-01'*/ select 1, 2, 3;
+SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000005';
+
+SET pg_tracing.max_parameter_size=5;
+/*traceparent='00-00000000000000000000000000000006-0000000000000006-01'*/ select 1, 2, 3;
+SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000006';
+CALL clean_spans();
+
+-- Test truncated string
+SET pg_tracing.max_parameter_size=2;
+/*traceparent='00-00000000000000000000000000000001-0000000000000001-01'*/ select 'testtruncatedstring';
+SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000001';
+
+SET pg_tracing.max_parameter_size=19;
+/*traceparent='00-00000000000000000000000000000002-0000000000000002-01'*/ select 'testtruncatedstring';
+SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000002';
+
+SET pg_tracing.max_parameter_size=20;
+/*traceparent='00-00000000000000000000000000000003-0000000000000003-01'*/ select 'testtruncatedstring';
+SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000003';
+
+SET pg_tracing.max_parameter_size=21;
+/*traceparent='00-00000000000000000000000000000004-0000000000000004-01'*/ select 'testtruncatedstring';
+SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000004';
+
+-- Cleanup
+CALL clean_spans();
+CALL reset_settings();

--- a/sql/parameters_16.sql
+++ b/sql/parameters_16.sql
@@ -1,0 +1,16 @@
+-- Saturate the parameter buffer with extended protocol
+SET pg_tracing.max_parameter_size=1;
+/*traceparent='00-00000000000000000000000000000001-0000000000000001-01'*/ select $1, $2, $3 \bind 1 2 3 \g
+SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000001';
+
+SET pg_tracing.max_parameter_size=2;
+/*traceparent='00-00000000000000000000000000000002-0000000000000002-01'*/ select $1, $2, $3 \bind 1 2 3 \g
+SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000002';
+
+SET pg_tracing.max_parameter_size=3;
+/*traceparent='00-00000000000000000000000000000003-0000000000000003-01'*/ select $1, $2, $3 \bind 1 2 3 \g
+SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000003';
+
+-- Cleanup
+CALL clean_spans();
+CALL reset_settings();

--- a/sql/select.sql
+++ b/sql/select.sql
@@ -64,12 +64,6 @@ SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='0
 /*dddbs='postgres.db',traceparent='00-0000000000000000000000000000000c-000000000000000c-01'*/ select 1; select 2;
 SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='0000000000000000000000000000000c';
 
--- Check that parameters are not exported when disabled
-SET pg_tracing.export_parameters=false;
-/*dddbs='postgres.db',traceparent='00-0000000000000000000000000000000d-000000000000000d-01'*/ select 1, 2, 3;
-SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='0000000000000000000000000000000d';
-SET pg_tracing.export_parameters=true;
-
 -- Check multi statement query
 CALL clean_spans();
 SET pg_tracing.sample_rate = 1.0;

--- a/sql/setup.sql
+++ b/sql/setup.sql
@@ -18,6 +18,7 @@ AS $$
     SET pg_tracing.sample_rate TO DEFAULT;
     SET pg_tracing.caller_sample_rate TO DEFAULT;
     SET pg_tracing.track_utility TO DEFAULT;
+    SET pg_tracing.max_parameter_size TO DEFAULT;
 $$;
 
 CREATE OR REPLACE PROCEDURE reset_pg_tracing_test_table() AS $$

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -206,6 +206,9 @@ typedef struct Span
 	uint8		subxact_count;	/* Active count of backend's subtransaction */
 
 	uint16		num_parameters; /* Number of parameters */
+	uint16		num_truncated_parameters;	/* Number of fully truncated
+											 * parameters due to reaching
+											 * max_parameter_size */
 
 	int			be_pid;			/* Pid of the backend process */
 	Oid			user_id;		/* User ID when the span was created */
@@ -213,13 +216,13 @@ typedef struct Span
 	int			worker_id;		/* Worker id */
 
 	/*
-	 * We store variable size metadata in an external file. Those represent
-	 * the position of NULL terminated strings in the file. Set to -1 if
+	 * We store variable size metadata in shared memory. Those represent the
+	 * position of NULL terminated strings in the shared_str. Set to -1 if
 	 * unused.
 	 */
-	Size		operation_name_offset;	/* operation represented by the span */
-	Size		parameter_offset;	/* query parameters values */
-	Size		deparse_info_offset;	/* info from deparsed plan */
+	int			operation_name_offset;	/* operation represented by the span */
+	int			parameter_offset;	/* query parameters values */
+	int			deparse_info_offset;	/* info from deparsed plan */
 
 	PlanCounters plan_counters; /* Counters with plan costs */
 	NodeCounters node_counters; /* Counters with node costs (jit, wal,
@@ -348,7 +351,7 @@ typedef struct SpanContext
 	const JumbleState *jstate;
 	const char *query_text;
 	uint64		query_id;
-	bool		export_parameters;
+	int			max_parameter_size;
 }			SpanContext;
 
 /* pg_tracing_explain.c */
@@ -382,9 +385,9 @@ extern TimestampTz
 			get_span_end_from_planstate(PlanState *planstate, TimestampTz plan_start, TimestampTz root_end);
 
 /* pg_tracing_query_process.c */
-extern const char *normalise_query_parameters(const JumbleState *jstate, const char *query,
-											  int query_loc, int *query_len_p, StringInfo trace_text,
-											  int *num_parameters);
+extern const char *normalise_query_parameters(const SpanContext * span_context, Span * span,
+											  int query_loc, int *query_len_p,
+											  StringInfo parameters_buffer);
 extern void extract_trace_context_from_query(Traceparent * traceparent, const char *query);
 extern ParseTraceparentErr parse_trace_context(Traceparent * traceparent, const char *trace_context_str, int trace_context_len);
 extern char *parse_code_to_err(ParseTraceparentErr err);
@@ -434,7 +437,9 @@ extern void
 			pg_tracing_shmem_startup(void);
 extern void reset_traceparent(Traceparent * traceparent);
 extern Size
-			append_str_to_shared_str(const char *txt, int str_len);
+			append_str_to_shared_str(const char *str, int str_len);
+extern int
+			append_str_to_parameters_buffer(const char *str, int str_len, bool add_null);
 
 /* pg_tracing_strinfo.c */
 extern int

--- a/src/pg_tracing_active_spans.c
+++ b/src/pg_tracing_active_spans.c
@@ -169,11 +169,9 @@ begin_active_span(const SpanContext * span_context, Span * span,
 	if (span_context->jstate && span_context->jstate->clocations_count > 0 && query != NULL)
 	{
 		/* jstate is available, normalise query and extract parameters' values */
-		int			num_parameters = 0;
-		int			parameter_offset = span_context->parameters_buffer->len;
 		StringInfo	parameters_buffer = NULL;
 
-		if (span_context->export_parameters)
+		if (span_context->max_parameter_size)
 
 			/*
 			 * We want parameters' value, propagate parameters_buffer
@@ -182,12 +180,9 @@ begin_active_span(const SpanContext * span_context, Span * span,
 			parameters_buffer = span_context->parameters_buffer;
 
 		query_len = query->stmt_len;
-		normalised_query = normalise_query_parameters(span_context->jstate, span_context->query_text,
+		normalised_query = normalise_query_parameters(span_context, span,
 													  query->stmt_location, &query_len,
-													  parameters_buffer, &num_parameters);
-		span->num_parameters = num_parameters;
-		if (num_parameters > 0 && span_context->export_parameters)
-			span->parameter_offset = parameter_offset;
+													  parameters_buffer);
 	}
 	else
 	{

--- a/src/pg_tracing_span.c
+++ b/src/pg_tracing_span.c
@@ -46,6 +46,7 @@ begin_span(TraceId trace_id, Span * span, SpanType type,
 	span->worker_id = -1;
 	span->operation_name_offset = -1;
 	span->num_parameters = 0;
+	span->num_truncated_parameters = 0;
 	span->parameter_offset = -1;
 	span->deparse_info_offset = -1;
 	span->sql_error_code = 0;


### PR DESCRIPTION
`pg_tracing.max_parameter_size` GUC parameter was present but never used. Use it to apply possibly truncate string stored in the parameter buffer shared across a traced transaction.
