### PR TITLE
Simplify parameter extraction in normalise query

### DIFF
--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -386,8 +386,7 @@ extern TimestampTz
 
 /* pg_tracing_query_process.c */
 extern const char *normalise_query_parameters(const SpanContext * span_context, Span * span,
-											  int query_loc, int *query_len_p,
-											  StringInfo parameters_buffer);
+											  int query_loc, int *query_len_p);
 extern void extract_trace_context_from_query(Traceparent * traceparent, const char *query);
 extern ParseTraceparentErr parse_trace_context(Traceparent * traceparent, const char *trace_context_str, int trace_context_len);
 extern char *parse_code_to_err(ParseTraceparentErr err);

--- a/src/pg_tracing_active_spans.c
+++ b/src/pg_tracing_active_spans.c
@@ -169,20 +169,9 @@ begin_active_span(const SpanContext * span_context, Span * span,
 	if (span_context->jstate && span_context->jstate->clocations_count > 0 && query != NULL)
 	{
 		/* jstate is available, normalise query and extract parameters' values */
-		StringInfo	parameters_buffer = NULL;
-
-		if (span_context->max_parameter_size)
-
-			/*
-			 * We want parameters' value, propagate parameters_buffer
-			 * StringInfo
-			 */
-			parameters_buffer = span_context->parameters_buffer;
-
 		query_len = query->stmt_len;
 		normalised_query = normalise_query_parameters(span_context, span,
-													  query->stmt_location, &query_len,
-													  parameters_buffer);
+													  query->stmt_location, &query_len);
 	}
 	else
 	{


### PR DESCRIPTION
We can rely on span_context containing max_parameter_size plus we don't need the parameters_buffer to be passed as argument anymore.