### PR TITLE
Preallocate spans before ExecutorRun

### DIFF
--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -384,6 +384,8 @@ extern int
 			get_parent_traced_planstate_index(int nested_level);
 extern TimestampTz
 			get_span_end_from_planstate(PlanState *planstate, TimestampTz plan_start, TimestampTz root_end);
+extern int
+			number_nodes_from_planstate(PlanState *planstate);
 
 /* pg_tracing_query_process.c */
 extern const char *normalise_query_parameters(const SpanContext * span_context, Span * span,


### PR DESCRIPTION
Preallocate spans before running ExecutorRun to avoid span allocations inside error handler.
