### PR TITLE
Cleaning and refactoring

### DIFF
--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -403,7 +403,6 @@ extern void end_span(Span * span, const TimestampTz *end_time);
 extern void reset_span(Span * span);
 extern const char *get_span_type(const Span * span);
 extern const char *get_operation_name(const Span * span);
-extern void adjust_file_offset(Span * span, Size file_position);
 extern bool traceid_zero(TraceId trace_id);
 extern bool traceid_equal(TraceId trace_id_1, TraceId trace_id_2);
 extern const char *span_type_to_str(SpanType span_type);

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -401,7 +401,6 @@ extern void begin_span(TraceId trace_id, Span * span, SpanType type,
 					   TimestampTz start_span);
 extern void end_span(Span * span, const TimestampTz *end_time);
 extern void reset_span(Span * span);
-extern const char *get_span_type(const Span * span);
 extern const char *get_operation_name(const Span * span);
 extern bool traceid_zero(TraceId trace_id);
 extern bool traceid_equal(TraceId trace_id_1, TraceId trace_id_2);
@@ -421,7 +420,6 @@ extern Span * push_child_active_span(MemoryContext context, const SpanContext * 
 									 SpanType span_type);
 
 extern void cleanup_active_spans(void);
-extern int	num_active_spans(void);
 
 /* pg_tracing.c */
 extern pgTracingSharedState * pg_tracing_shared_state;

--- a/src/pg_tracing_active_spans.c
+++ b/src/pg_tracing_active_spans.c
@@ -31,15 +31,6 @@ cleanup_active_spans(void)
 }
 
 /*
- * Return the number of active spans currently in the stack
- */
-int
-num_active_spans(void)
-{
-	return active_spans->end;
-}
-
-/*
  * Push a new active span to the active_spans stack
  */
 static Span *

--- a/src/pg_tracing_planstate.c
+++ b/src/pg_tracing_planstate.c
@@ -539,7 +539,6 @@ create_span_node(PlanState *planstate, const planstateTraceContext * planstateTr
 		span.parallel_aware = plan->parallel_aware;
 		span.async_capable = plan->async_capable;
 
-		span_type = plan_to_span_type(plan);
 		operation_name = plan_to_rel_name(planstateTraceContext, planstate);
 		len_operation_name = strlen(operation_name);
 		if (len_operation_name > 0)

--- a/src/pg_tracing_span.c
+++ b/src/pg_tracing_span.c
@@ -323,20 +323,6 @@ get_operation_name(const Span * span)
 }
 
 /*
- * Adjust span's offsets with the provided file offset
- */
-void
-adjust_file_offset(Span * span, Size file_position)
-{
-	if (span->operation_name_offset != -1)
-		span->operation_name_offset += file_position;
-	if (span->parameter_offset != -1)
-		span->parameter_offset += file_position;
-	if (span->deparse_info_offset != -1)
-		span->deparse_info_offset += file_position;
-}
-
-/*
 * Returns true if TraceId is zero
 */
 bool


### PR DESCRIPTION
- Remove unused functions
- Use planstate_walker to handle ExecProcNode overrides
- Always provide a valid timestamp to end_nested_level