### PR TITLE
Don't walk into Gather subplans if there's no local scan

### DIFF
--- a/expected/parallel.out
+++ b/expected/parallel.out
@@ -62,6 +62,35 @@ SELECT count(*) from pg_tracing_consume_spans where span_operation='ExecutorRun'
      7
 (1 row)
 
+CALL clean_spans();
+-- Test leaderless parallel query
+set parallel_setup_cost=0;
+set parallel_tuple_cost=0;
+set min_parallel_table_scan_size=0;
+set max_parallel_workers_per_gather=2;
+set parallel_leader_participation=false;
+/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000001-0000000000000001-01'*/ select 1 from pg_class limit 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+SELECT span_type, span_operation, lvl FROM peek_ordered_spans where trace_id='00000000000000000000000000000001' ORDER BY lvl, span_operation;
+  span_type   |          span_operation           | lvl 
+--------------+-----------------------------------+-----
+ Select query | select $1 from pg_class limit $2; |   1
+ ExecutorRun  | ExecutorRun                       |   2
+ Planner      | Planner                           |   2
+ Limit        | Limit                             |   3
+ Select query | Worker 0                          |   3
+ Select query | Worker 1                          |   3
+ ExecutorRun  | ExecutorRun                       |   4
+ ExecutorRun  | ExecutorRun                       |   4
+ Gather       | Gather                            |   4
+ SeqScan      | SeqScan on pg_class               |   5
+ SeqScan      | SeqScan on pg_class               |   5
+(11 rows)
+
 -- Cleanup
 CALL clean_spans();
 CALL reset_settings();

--- a/expected/setup.out
+++ b/expected/setup.out
@@ -17,6 +17,10 @@ AS $$
     SET pg_tracing.caller_sample_rate TO DEFAULT;
     SET pg_tracing.track_utility TO DEFAULT;
     SET pg_tracing.max_parameter_size TO DEFAULT;
+    SET parallel_setup_cost TO DEFAULT;
+    SET parallel_tuple_cost TO DEFAULT;
+    SET min_parallel_table_scan_size TO DEFAULT;
+    SET max_parallel_workers_per_gather TO DEFAULT;
 $$;
 CREATE OR REPLACE PROCEDURE reset_pg_tracing_test_table() AS $$
 BEGIN

--- a/sql/parallel.sql
+++ b/sql/parallel.sql
@@ -30,6 +30,17 @@ SELECT trace_id from pg_tracing_peek_spans group by trace_id;
 
 -- Check number of executor spans
 SELECT count(*) from pg_tracing_consume_spans where span_operation='ExecutorRun';
+CALL clean_spans();
+
+-- Test leaderless parallel query
+set parallel_setup_cost=0;
+set parallel_tuple_cost=0;
+set min_parallel_table_scan_size=0;
+set max_parallel_workers_per_gather=2;
+set parallel_leader_participation=false;
+/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000001-0000000000000001-01'*/ select 1 from pg_class limit 1;
+
+SELECT span_type, span_operation, lvl FROM peek_ordered_spans where trace_id='00000000000000000000000000000001' ORDER BY lvl, span_operation;
 
 -- Cleanup
 CALL clean_spans();

--- a/sql/setup.sql
+++ b/sql/setup.sql
@@ -19,6 +19,10 @@ AS $$
     SET pg_tracing.caller_sample_rate TO DEFAULT;
     SET pg_tracing.track_utility TO DEFAULT;
     SET pg_tracing.max_parameter_size TO DEFAULT;
+    SET parallel_setup_cost TO DEFAULT;
+    SET parallel_tuple_cost TO DEFAULT;
+    SET min_parallel_table_scan_size TO DEFAULT;
+    SET max_parallel_workers_per_gather TO DEFAULT;
 $$;
 
 CREATE OR REPLACE PROCEDURE reset_pg_tracing_test_table() AS $$


### PR DESCRIPTION
Parallel queries executed without the leader participation won't execute the sub nodes in Gather/GatherMerge, which is represented by `need_to_scan_locally=false`. Since the nodes won't be executed, we won't have a traced plan and there's no value to generate spans from those nodes. 

We just need to skip the whole subtree in those cases.

Fixes #54 