### PR TITLE
Set gather/gathermerge as parent of parallel workers

### DIFF
--- a/expected/parallel.out
+++ b/expected/parallel.out
@@ -11,13 +11,13 @@ set local max_parallel_workers_per_gather=2;
         1
 (1 row)
 
-/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000002-0000000000000002-01'*/ select 2 from pg_class limit 1;
+/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000001-0000000000000002-01'*/ select 2 from pg_class limit 1;
  ?column? 
 ----------
         2
 (1 row)
 
-/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000003-0000000000000003-00'*/ select 3 from pg_class limit 1;
+/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000001-0000000000000003-00'*/ select 3 from pg_class limit 1;
  ?column? 
 ----------
         3
@@ -25,7 +25,7 @@ set local max_parallel_workers_per_gather=2;
 
 -- Try with parallel tracing disabled
 set local pg_tracing.trace_parallel_workers = false;
-/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000004-0000000000000004-01'*/ select 4 from pg_class limit 1;
+/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000001-0000000000000004-01'*/ select 4 from pg_class limit 1;
  ?column? 
 ----------
         4
@@ -35,11 +35,15 @@ commit;
 -- get tx block
 select span_id as tx_block_id from pg_tracing_peek_spans where span_type='TransactionBlock' and trace_id='00000000000000000000000000000001' and parent_id='0000000000000001' \gset
 -- get root top span id
-select span_id as root_span_id from pg_tracing_peek_spans where span_type='Select query' and trace_id='00000000000000000000000000000001' and parent_id=:'tx_block_id' \gset
+select span_id as root_span_id from pg_tracing_peek_spans where span_type='Select query' and trace_id='00000000000000000000000000000001' and parent_id=:'tx_block_id' limit 1 \gset
 -- Get executor top span id
 SELECT span_id as executor_span_id from pg_tracing_peek_spans where span_operation='ExecutorRun' and trace_id='00000000000000000000000000000001' and parent_id=:'root_span_id' \gset
+-- Get Limit span id
+SELECT span_id as limit_span_id from pg_tracing_peek_spans where span_operation='Limit' and trace_id='00000000000000000000000000000001' and parent_id=:'executor_span_id' \gset
+-- Get Gather span id
+SELECT span_id as gather_span_id from pg_tracing_peek_spans where span_operation='Gather' and trace_id='00000000000000000000000000000001' and parent_id=:'limit_span_id' \gset
 -- Check the select spans that are attached to the root top span
-SELECT trace_id, span_type, span_operation from pg_tracing_peek_spans where span_type='Select query' and parent_id=:'executor_span_id' order by span_operation;
+SELECT trace_id, span_type, span_operation from pg_tracing_peek_spans where span_type='Select query' and parent_id=:'gather_span_id' order by span_operation;
              trace_id             |  span_type   | span_operation 
 ----------------------------------+--------------+----------------
  00000000000000000000000000000001 | Select query | Worker 0
@@ -51,9 +55,7 @@ SELECT trace_id from pg_tracing_peek_spans group by trace_id;
              trace_id             
 ----------------------------------
  00000000000000000000000000000001
- 00000000000000000000000000000004
- 00000000000000000000000000000002
-(3 rows)
+(1 row)
 
 -- Check number of executor spans
 SELECT count(*) from pg_tracing_consume_spans where span_operation='ExecutorRun';
@@ -82,13 +84,13 @@ SELECT span_type, span_operation, lvl FROM peek_ordered_spans where trace_id='00
  ExecutorRun  | ExecutorRun                       |   2
  Planner      | Planner                           |   2
  Limit        | Limit                             |   3
- Select query | Worker 0                          |   3
- Select query | Worker 1                          |   3
- ExecutorRun  | ExecutorRun                       |   4
- ExecutorRun  | ExecutorRun                       |   4
  Gather       | Gather                            |   4
- SeqScan      | SeqScan on pg_class               |   5
- SeqScan      | SeqScan on pg_class               |   5
+ Select query | Worker 0                          |   5
+ Select query | Worker 1                          |   5
+ ExecutorRun  | ExecutorRun                       |   6
+ ExecutorRun  | ExecutorRun                       |   6
+ SeqScan      | SeqScan on pg_class               |   7
+ SeqScan      | SeqScan on pg_class               |   7
 (11 rows)
 
 -- Cleanup

--- a/sql/parallel.sql
+++ b/sql/parallel.sql
@@ -7,23 +7,27 @@ set local max_parallel_workers_per_gather=2;
 
 -- Trace parallel queries
 /*dddbs='postgres.db',traceparent='00-00000000000000000000000000000001-0000000000000001-01'*/ select 1 from pg_class limit 1;
-/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000002-0000000000000002-01'*/ select 2 from pg_class limit 1;
-/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000003-0000000000000003-00'*/ select 3 from pg_class limit 1;
+/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000001-0000000000000002-01'*/ select 2 from pg_class limit 1;
+/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000001-0000000000000003-00'*/ select 3 from pg_class limit 1;
 
 -- Try with parallel tracing disabled
 set local pg_tracing.trace_parallel_workers = false;
-/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000004-0000000000000004-01'*/ select 4 from pg_class limit 1;
+/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000001-0000000000000004-01'*/ select 4 from pg_class limit 1;
 commit;
 
 -- get tx block
 select span_id as tx_block_id from pg_tracing_peek_spans where span_type='TransactionBlock' and trace_id='00000000000000000000000000000001' and parent_id='0000000000000001' \gset
 -- get root top span id
-select span_id as root_span_id from pg_tracing_peek_spans where span_type='Select query' and trace_id='00000000000000000000000000000001' and parent_id=:'tx_block_id' \gset
+select span_id as root_span_id from pg_tracing_peek_spans where span_type='Select query' and trace_id='00000000000000000000000000000001' and parent_id=:'tx_block_id' limit 1 \gset
 -- Get executor top span id
 SELECT span_id as executor_span_id from pg_tracing_peek_spans where span_operation='ExecutorRun' and trace_id='00000000000000000000000000000001' and parent_id=:'root_span_id' \gset
+-- Get Limit span id
+SELECT span_id as limit_span_id from pg_tracing_peek_spans where span_operation='Limit' and trace_id='00000000000000000000000000000001' and parent_id=:'executor_span_id' \gset
+-- Get Gather span id
+SELECT span_id as gather_span_id from pg_tracing_peek_spans where span_operation='Gather' and trace_id='00000000000000000000000000000001' and parent_id=:'limit_span_id' \gset
 
 -- Check the select spans that are attached to the root top span
-SELECT trace_id, span_type, span_operation from pg_tracing_peek_spans where span_type='Select query' and parent_id=:'executor_span_id' order by span_operation;
+SELECT trace_id, span_type, span_operation from pg_tracing_peek_spans where span_type='Select query' and parent_id=:'gather_span_id' order by span_operation;
 
 -- Check generated trace_id
 SELECT trace_id from pg_tracing_peek_spans group by trace_id;

--- a/src/pg_tracing.c
+++ b/src/pg_tracing.c
@@ -1832,6 +1832,7 @@ pg_tracing_ExecutorRun(QueryDesc *queryDesc, ScanDirection direction, uint64 cou
 	Span	   *executor_run_span;
 	Traceparent *traceparent = &executor_traceparent;
 	int			num_nodes;
+	uint64		parallel_workers_parent_id = 0;
 
 	if (!pg_tracing_enabled(traceparent, nested_level) || queryDesc->totaltime == NULL)
 	{
@@ -1876,7 +1877,10 @@ pg_tracing_ExecutorRun(QueryDesc *queryDesc, ScanDirection direction, uint64 cou
 	 * child processes
 	 */
 	if (queryDesc->plannedstmt->parallelModeNeeded && pg_tracing_trace_parallel_workers)
-		add_parallel_context(traceparent, executor_run_span->span_id);
+	{
+		parallel_workers_parent_id = generate_parallel_workers_parent_id();
+		add_parallel_context(traceparent, parallel_workers_parent_id);
+	}
 
 	/*
 	 * Setup ExecProcNode override to capture node start if planstate spans

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -386,6 +386,8 @@ extern TimestampTz
 			get_span_end_from_planstate(PlanState *planstate, TimestampTz plan_start, TimestampTz root_end);
 extern int
 			number_nodes_from_planstate(PlanState *planstate);
+extern uint64
+			generate_parallel_workers_parent_id(void);
 
 /* pg_tracing_query_process.c */
 extern const char *normalise_query_parameters(const SpanContext * span_context, Span * span,


### PR DESCRIPTION
Currently, workers are created as children of ExecutorRun, leaving the Gather/GatherMerge node isolated and without any relation with the rest of the parallel queries.

This patch moves the Gather/GatherMerge node to be a parent of the worker's nodes.