### PR TITLE
Avoid compiler warnings about unused variable

### DIFF
--- a/src/pg_tracing.c
+++ b/src/pg_tracing.c
@@ -1361,7 +1361,7 @@ handle_pg_error(const Traceparent * traceparent,
 {
 	int			sql_error_code;
 	Span	   *span;
-	int			max_trace_spans = current_trace_spans->max;
+	int			max_trace_spans PG_USED_FOR_ASSERTS_ONLY = current_trace_spans->max;
 
 	sql_error_code = geterrcode();
 


### PR DESCRIPTION
As max_trace_spans is used only for ASSERT, declare it with PG_USED_FOR_ASSERTS_ONLY.