### PR TITLE
Renaming And Refactoring

### DIFF
--- a/expected/utility.out
+++ b/expected/utility.out
@@ -59,8 +59,8 @@ CREATE EXTENSION pg_tracing;
 SET pg_tracing.sample_rate = 0.0;
 -- View displaying spans with their nested level
 CREATE VIEW peek_spans_with_level AS
-    WITH RECURSIVE list_trace_spans(trace_id, parent_id, span_id, query_id, span_type, span_operation, span_start, span_end, sql_error_code, userid, dbid, pid, subxact_count, plan_startup_cost, plan_total_cost, plan_rows, plan_width, rows, nloops, shared_blks_hit, shared_blks_read, shared_blks_dirtied, shared_blks_written, local_blks_hit, local_blks_read, local_blks_dirtied, local_blks_written, blk_read_time, blk_write_time, temp_blks_read, temp_blks_written, temp_blk_read_time, temp_blk_write_time, wal_records, wal_fpi, wal_bytes, jit_functions, jit_generation_time, jit_inlining_time, jit_optimization_time, jit_emission_time, startup, parameters, deparse_info, lvl) AS (
-        SELECT p.*, 1
+    WITH RECURSIVE list_trace_spans AS (
+        SELECT p.*, 1 as lvl
         FROM pg_tracing_peek_spans p where not parent_id=ANY(SELECT span_id from pg_tracing_peek_spans)
       UNION ALL
         SELECT s.*, lvl + 1

--- a/sql/utility.sql
+++ b/sql/utility.sql
@@ -67,8 +67,8 @@ SET pg_tracing.sample_rate = 0.0;
 
 -- View displaying spans with their nested level
 CREATE VIEW peek_spans_with_level AS
-    WITH RECURSIVE list_trace_spans(trace_id, parent_id, span_id, query_id, span_type, span_operation, span_start, span_end, sql_error_code, userid, dbid, pid, subxact_count, plan_startup_cost, plan_total_cost, plan_rows, plan_width, rows, nloops, shared_blks_hit, shared_blks_read, shared_blks_dirtied, shared_blks_written, local_blks_hit, local_blks_read, local_blks_dirtied, local_blks_written, blk_read_time, blk_write_time, temp_blks_read, temp_blks_written, temp_blk_read_time, temp_blk_write_time, wal_records, wal_fpi, wal_bytes, jit_functions, jit_generation_time, jit_inlining_time, jit_optimization_time, jit_emission_time, startup, parameters, deparse_info, lvl) AS (
-        SELECT p.*, 1
+    WITH RECURSIVE list_trace_spans AS (
+        SELECT p.*, 1 as lvl
         FROM pg_tracing_peek_spans p where not parent_id=ANY(SELECT span_id from pg_tracing_peek_spans)
       UNION ALL
         SELECT s.*, lvl + 1

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -197,9 +197,6 @@ typedef struct Span
 	SpanType	type;			/* Type of the span. Used to generate the
 								 * span's name */
 
-	bool		parallel_aware;
-	bool		async_capable;
-
 	int8		nested_level;	/* Nested level of this span this span.
 								 * Internal usage only */
 	int8		parent_planstate_index; /* Index to the parent planstate of

--- a/src/pg_tracing_planstate.c
+++ b/src/pg_tracing_planstate.c
@@ -602,9 +602,6 @@ create_span_node(PlanState *planstate, const planstateTraceContext * planstateTr
 		const char *operation_name;
 		int			len_operation_name;
 
-		span.parallel_aware = plan->parallel_aware;
-		span.async_capable = plan->async_capable;
-
 		operation_name = plan_to_rel_name(planstateTraceContext, planstate);
 		len_operation_name = strlen(operation_name);
 		if (len_operation_name > 0)

--- a/src/pg_tracing_planstate.c
+++ b/src/pg_tracing_planstate.c
@@ -177,7 +177,7 @@ drop_traced_planstates(void)
  * It will track the time of the first node call needed to place the planstate span.
  */
 static TupleTableSlot *
-ExecProcNodeFirstPgTracing(PlanState *node)
+ExecProcNodeFirstPgTracing(PlanState *planstate)
 {
 	uint64		span_id;
 
@@ -201,7 +201,7 @@ ExecProcNodeFirstPgTracing(PlanState *node)
 									  max_planstart * sizeof(TracedPlanstate));
 	}
 
-	switch (nodeTag(node))
+	switch (nodeTag(planstate))
 	{
 		case T_GatherState:
 		case T_GatherMergeState:
@@ -218,7 +218,7 @@ ExecProcNodeFirstPgTracing(PlanState *node)
 	}
 
 	/* Register planstate start */
-	traced_planstates[index_planstart].planstate = node;
+	traced_planstates[index_planstart].planstate = planstate;
 	traced_planstates[index_planstart].node_start = GetCurrentTimestamp();
 	traced_planstates[index_planstart].span_id = span_id;
 	traced_planstates[index_planstart].nested_level = nested_level;
@@ -226,8 +226,8 @@ ExecProcNodeFirstPgTracing(PlanState *node)
 
 exit:
 	/* Restore previous exec proc */
-	node->ExecProcNode = previous_ExecProcNode;
-	return node->ExecProcNode(node);
+	planstate->ExecProcNode = previous_ExecProcNode;
+	return planstate->ExecProcNode(planstate);
 }
 
 /*

--- a/src/pg_tracing_span.c
+++ b/src/pg_tracing_span.c
@@ -41,8 +41,6 @@ begin_span(TraceId trace_id, Span * span, SpanType type,
 	else
 		span->span_id = pg_prng_uint64(&pg_global_prng_state);
 
-	span->parallel_aware = false;
-	span->async_capable = false;
 	span->worker_id = -1;
 	span->operation_name_offset = -1;
 	span->num_parameters = 0;


### PR DESCRIPTION
- Remove unnecessary span fields (asyn_capable and parallel_aware)
- Renamed PerLevelBuffers fields to avoid confusion with ExecutorStart and ExecutorEnd
- Remove unnecessary column names in peek with level view definition