### PR TITLE
Allow changing otel endpoint setting without restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,3 +155,5 @@ pg_tracing.otel_naptime = 2000
 ```
 
 If an otel endpoint is defined, a background worker will be started and will send spans every $naptime using the OTLP HTTP/JSON protocol.
+The endpoint can be changed while the server is running, but if it was not set when the server was started, changing it to non-empty value
+requires a restart.

--- a/src/pg_tracing.h
+++ b/src/pg_tracing.h
@@ -426,6 +426,9 @@ extern pgTracingSpans * shared_spans;
 extern char *shared_str;
 extern int	nested_level;
 extern char *pg_tracing_otel_service_name;
+extern char *pg_tracing_otel_endpoint;
+extern int	pg_tracing_otel_naptime;
+extern int	pg_tracing_otel_connect_timeout_ms;
 
 extern void
 			store_span(const Span * span);
@@ -464,6 +467,12 @@ extern Size
 
 /* pg_tracing_otel.c */
 extern void
-			pg_tracing_start_worker(const char *endpoint, int naptime, int connect_timeout_ms);
+			pg_tracing_start_worker(void);
+
+extern void
+			otel_config_int_assign_hook(int newval, void *extra);
+
+extern void
+			otel_config_string_assign_hook(const char *newval, void *extra);
 
 #endif


### PR DESCRIPTION
Also the naptime and connection timeout settings. If no endpoint was set at server start, though, the background worker is not started, and changing the endpoint will have no effect. Similarly, if you set endpoint to empty while the server is running, the background worker will keep running, but won't do anything. Changing the registration of the background worker in response to config changes is difficult. But at least you can change the endpoint without a restart.
