### PR TITLE
Add peek span view with tree visualisation of spans

### DIFF
--- a/expected/cleanup.out
+++ b/expected/cleanup.out
@@ -3,7 +3,6 @@ DROP TABLE pg_tracing_test;
 DROP function test_function_project_set;
 DROP function test_function_result;
 DROP VIEW peek_ordered_spans;
-DROP VIEW peek_spans_with_level;
 DROP VIEW peek_ordered_json_spans;
 DROP VIEW peek_json_spans_with_level;
 DROP VIEW peek_json_spans;

--- a/expected/cursor.out
+++ b/expected/cursor.out
@@ -142,26 +142,26 @@ SELECT :span_d_start >= :span_c_start as nested_declare_starts_after_parent,
 SELECT span_type, span_operation, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000001';
     span_type     |                   span_operation                    | lvl 
 ------------------+-----------------------------------------------------+-----
- TransactionBlock | TransactionBlock                                    |   1
- Utility query    | BEGIN;                                              |   2
- ProcessUtility   | ProcessUtility                                      |   3
- Utility query    | DECLARE c CURSOR FOR SELECT * from pg_tracing_test; |   2
- ProcessUtility   | ProcessUtility                                      |   3
- Select query     | DECLARE c CURSOR FOR SELECT * from pg_tracing_test; |   4
- Planner          | Planner                                             |   5
- Utility query    | FETCH FORWARD 20 from c                             |   2
- ProcessUtility   | ProcessUtility                                      |   3
- Select query     | DECLARE c CURSOR FOR SELECT * from pg_tracing_test; |   4
- ExecutorRun      | ExecutorRun                                         |   5
- Utility query    | FETCH BACKWARD 10 from c                            |   2
- ProcessUtility   | ProcessUtility                                      |   3
- Select query     | DECLARE c CURSOR FOR SELECT * from pg_tracing_test; |   4
- ExecutorRun      | ExecutorRun                                         |   5
- Utility query    | CLOSE c;                                            |   2
- ProcessUtility   | ProcessUtility                                      |   3
- Select query     | DECLARE c CURSOR FOR SELECT * from pg_tracing_test; |   4
- Utility query    | COMMIT;                                             |   2
- ProcessUtility   | ProcessUtility                                      |   3
+ TransactionBlock | TransactionBlock                                    |   0
+ Utility query    | BEGIN;                                              |   1
+ ProcessUtility   | ProcessUtility                                      |   2
+ Utility query    | DECLARE c CURSOR FOR SELECT * from pg_tracing_test; |   1
+ ProcessUtility   | ProcessUtility                                      |   2
+ Select query     | DECLARE c CURSOR FOR SELECT * from pg_tracing_test; |   3
+ Planner          | Planner                                             |   4
+ Utility query    | FETCH FORWARD 20 from c                             |   1
+ ProcessUtility   | ProcessUtility                                      |   2
+ Select query     | DECLARE c CURSOR FOR SELECT * from pg_tracing_test; |   3
+ ExecutorRun      | ExecutorRun                                         |   4
+ Utility query    | FETCH BACKWARD 10 from c                            |   1
+ ProcessUtility   | ProcessUtility                                      |   2
+ Select query     | DECLARE c CURSOR FOR SELECT * from pg_tracing_test; |   3
+ ExecutorRun      | ExecutorRun                                         |   4
+ Utility query    | CLOSE c;                                            |   1
+ ProcessUtility   | ProcessUtility                                      |   2
+ Select query     | DECLARE c CURSOR FOR SELECT * from pg_tracing_test; |   3
+ Utility query    | COMMIT;                                             |   1
+ ProcessUtility   | ProcessUtility                                      |   2
 (20 rows)
 
 -- Clean created spans

--- a/expected/extended.out
+++ b/expected/extended.out
@@ -10,10 +10,10 @@ SELECT $1, $2 \bind 1 2 \g
 SELECT span_type, span_operation, parameters, lvl FROM peek_ordered_spans;
   span_type   | span_operation | parameters | lvl 
 --------------+----------------+------------+-----
- Select query | SELECT $1, $2  | {1,2}      |   1
- Planner      | Planner        |            |   2
- ExecutorRun  | ExecutorRun    |            |   2
- Result       | Result         |            |   3
+ Select query | SELECT $1, $2  | {1,2}      |   0
+ Planner      | Planner        |            |   1
+ ExecutorRun  | ExecutorRun    |            |   1
+ Result       | Result         |            |   2
 (4 rows)
 
 CALL clean_spans();
@@ -24,12 +24,12 @@ ROLLBACK;
 SELECT span_type, span_operation, parameters, lvl FROM peek_ordered_spans;
     span_type     |  span_operation  | parameters | lvl 
 ------------------+------------------+------------+-----
- TransactionBlock | TransactionBlock |            |   1
- Utility query    | BEGIN;           |            |   2
- ProcessUtility   | ProcessUtility   |            |   3
- Select query     | select $1        |            |   2
- Utility query    | ROLLBACK;        |            |   1
+ TransactionBlock | TransactionBlock |            |   0
+ Utility query    | BEGIN;           |            |   1
  ProcessUtility   | ProcessUtility   |            |   2
+ Select query     | select $1        |            |   1
+ Utility query    | ROLLBACK;        |            |   0
+ ProcessUtility   | ProcessUtility   |            |   1
 (6 rows)
 
 CALL clean_spans();
@@ -67,28 +67,28 @@ SELECT count(distinct(trace_id)) = 1 FROM pg_tracing_peek_spans;
 SELECT span_type, span_operation, parameters, lvl FROM peek_ordered_spans;
     span_type     |  span_operation  | parameters | lvl 
 ------------------+------------------+------------+-----
- TransactionBlock | TransactionBlock |            |   1
- Utility query    | BEGIN;           |            |   2
- ProcessUtility   | ProcessUtility   |            |   3
- Select query     | SELECT $1        | {1}        |   2
- Planner          | Planner          |            |   3
- ExecutorRun      | ExecutorRun      |            |   3
- Result           | Result           |            |   4
- Select query     | SELECT $1, $2    | {2,3}      |   2
- Planner          | Planner          |            |   3
- ExecutorRun      | ExecutorRun      |            |   3
- Result           | Result           |            |   4
- Utility query    | COMMIT;          |            |   2
- ProcessUtility   | ProcessUtility   |            |   3
- TransactionBlock | TransactionBlock |            |   1
- Utility query    | BEGIN;           |            |   2
- ProcessUtility   | ProcessUtility   |            |   3
- Select query     | SELECT $1        | {1}        |   2
- Planner          | Planner          |            |   3
- ExecutorRun      | ExecutorRun      |            |   3
- Result           | Result           |            |   4
- Utility query    | COMMIT;          |            |   2
- ProcessUtility   | ProcessUtility   |            |   3
+ TransactionBlock | TransactionBlock |            |   0
+ Utility query    | BEGIN;           |            |   1
+ ProcessUtility   | ProcessUtility   |            |   2
+ Select query     | SELECT $1        | {1}        |   1
+ Planner          | Planner          |            |   2
+ ExecutorRun      | ExecutorRun      |            |   2
+ Result           | Result           |            |   3
+ Select query     | SELECT $1, $2    | {2,3}      |   1
+ Planner          | Planner          |            |   2
+ ExecutorRun      | ExecutorRun      |            |   2
+ Result           | Result           |            |   3
+ Utility query    | COMMIT;          |            |   1
+ ProcessUtility   | ProcessUtility   |            |   2
+ TransactionBlock | TransactionBlock |            |   0
+ Utility query    | BEGIN;           |            |   1
+ ProcessUtility   | ProcessUtility   |            |   2
+ Select query     | SELECT $1        | {1}        |   1
+ Planner          | Planner          |            |   2
+ ExecutorRun      | ExecutorRun      |            |   2
+ Result           | Result           |            |   3
+ Utility query    | COMMIT;          |            |   1
+ ProcessUtility   | ProcessUtility   |            |   2
 (22 rows)
 
 CALL clean_spans();
@@ -123,23 +123,23 @@ SELECT count(distinct(trace_id)) = 1 FROM pg_tracing_peek_spans;
 SELECT span_type, span_operation, parameters, lvl FROM peek_ordered_spans;
     span_type     |   span_operation   | parameters | lvl 
 ------------------+--------------------+------------+-----
- TransactionBlock | TransactionBlock   |            |   1
- Utility query    | BEGIN;             |            |   2
- ProcessUtility   | ProcessUtility     |            |   3
- Select query     | SELECT $1          | {1}        |   2
- Planner          | Planner            |            |   3
- ExecutorRun      | ExecutorRun        |            |   3
- Result           | Result             |            |   4
- Select query     | SELECT $1, $2, $3; | {5,6,7}    |   2
- Planner          | Planner            |            |   3
- ExecutorRun      | ExecutorRun        |            |   3
- Result           | Result             |            |   4
- Select query     | SELECT $1, $2      | {2,3}      |   2
- Planner          | Planner            |            |   3
- ExecutorRun      | ExecutorRun        |            |   3
- Result           | Result             |            |   4
- Utility query    | COMMIT;            |            |   2
- ProcessUtility   | ProcessUtility     |            |   3
+ TransactionBlock | TransactionBlock   |            |   0
+ Utility query    | BEGIN;             |            |   1
+ ProcessUtility   | ProcessUtility     |            |   2
+ Select query     | SELECT $1          | {1}        |   1
+ Planner          | Planner            |            |   2
+ ExecutorRun      | ExecutorRun        |            |   2
+ Result           | Result             |            |   3
+ Select query     | SELECT $1, $2, $3; | {5,6,7}    |   1
+ Planner          | Planner            |            |   2
+ ExecutorRun      | ExecutorRun        |            |   2
+ Result           | Result             |            |   3
+ Select query     | SELECT $1, $2      | {2,3}      |   1
+ Planner          | Planner            |            |   2
+ ExecutorRun      | ExecutorRun        |            |   2
+ Result           | Result             |            |   3
+ Utility query    | COMMIT;            |            |   1
+ ProcessUtility   | ProcessUtility     |            |   2
 (17 rows)
 
 CALL clean_spans();
@@ -153,12 +153,12 @@ SELECT 1 \gdesc
 SELECT span_type, span_operation, parameters, lvl FROM peek_ordered_spans;
   span_type   |                           span_operation                           |      parameters      | lvl 
 --------------+--------------------------------------------------------------------+----------------------+-----
- Select query | SELECT $1                                                          | {1}                  |   1
- Select query | SELECT name AS "Column", pg_catalog.format_type(tp, tpm) AS "Type"+| {'?column?','23',-1} |   1
+ Select query | SELECT $1                                                          | {1}                  |   0
+ Select query | SELECT name AS "Column", pg_catalog.format_type(tp, tpm) AS "Type"+| {'?column?','23',-1} |   0
               | FROM (VALUES ($1, $2::pg_catalog.oid,$3)) s(name, tp, tpm)         |                      | 
- Planner      | Planner                                                            |                      |   2
- ExecutorRun  | ExecutorRun                                                        |                      |   2
- Result       | Result                                                             |                      |   3
+ Planner      | Planner                                                            |                      |   1
+ ExecutorRun  | ExecutorRun                                                        |                      |   1
+ Result       | Result                                                             |                      |   2
 (5 rows)
 
 CALL clean_spans();
@@ -188,23 +188,23 @@ COMMIT;
 SELECT span_type, span_operation, parameters, lvl FROM peek_ordered_spans WHERE trace_id='00000000000000000000000000000001';
     span_type     |  span_operation   | parameters | lvl 
 ------------------+-------------------+------------+-----
- TransactionBlock | TransactionBlock  |            |   1
- Utility query    | BEGIN;            |            |   2
- ProcessUtility   | ProcessUtility    |            |   3
- Select query     | SELECT $1         | {1}        |   2
- Planner          | Planner           |            |   3
- ExecutorRun      | ExecutorRun       |            |   3
- Result           | Result            |            |   4
- Select query     | SELECT $1, $2     | {1,2}      |   2
- Planner          | Planner           |            |   3
- ExecutorRun      | ExecutorRun       |            |   3
- Result           | Result            |            |   4
- Select query     | SELECT $1, $2, $3 | {1,2,3}    |   2
- Planner          | Planner           |            |   3
- ExecutorRun      | ExecutorRun       |            |   3
- Result           | Result            |            |   4
- Utility query    | COMMIT;           |            |   2
- ProcessUtility   | ProcessUtility    |            |   3
+ TransactionBlock | TransactionBlock  |            |   0
+ Utility query    | BEGIN;            |            |   1
+ ProcessUtility   | ProcessUtility    |            |   2
+ Select query     | SELECT $1         | {1}        |   1
+ Planner          | Planner           |            |   2
+ ExecutorRun      | ExecutorRun       |            |   2
+ Result           | Result            |            |   3
+ Select query     | SELECT $1, $2     | {1,2}      |   1
+ Planner          | Planner           |            |   2
+ ExecutorRun      | ExecutorRun       |            |   2
+ Result           | Result            |            |   3
+ Select query     | SELECT $1, $2, $3 | {1,2,3}    |   1
+ Planner          | Planner           |            |   2
+ ExecutorRun      | ExecutorRun       |            |   2
+ Result           | Result            |            |   3
+ Utility query    | COMMIT;           |            |   1
+ ProcessUtility   | ProcessUtility    |            |   2
 (17 rows)
 
 -- Test tracing only individual statements with extended protocol
@@ -231,19 +231,19 @@ COMMIT;
 SELECT span_type, span_operation, parameters, lvl FROM peek_ordered_spans WHERE trace_id='00000000000000000000000000000002';
     span_type     |  span_operation   | parameters | lvl 
 ------------------+-------------------+------------+-----
- TransactionBlock | TransactionBlock  |            |   1
- Select query     | SELECT $1         | {1}        |   2
- Planner          | Planner           |            |   3
- ExecutorRun      | ExecutorRun       |            |   3
- Result           | Result            |            |   4
- Select query     | SELECT $1, $2     | {1,2}      |   2
- Planner          | Planner           |            |   3
- ExecutorRun      | ExecutorRun       |            |   3
- Result           | Result            |            |   4
- Select query     | SELECT $1, $2, $3 | {1,2,3}    |   2
- Planner          | Planner           |            |   3
- ExecutorRun      | ExecutorRun       |            |   3
- Result           | Result            |            |   4
+ TransactionBlock | TransactionBlock  |            |   0
+ Select query     | SELECT $1         | {1}        |   1
+ Planner          | Planner           |            |   2
+ ExecutorRun      | ExecutorRun       |            |   2
+ Result           | Result            |            |   3
+ Select query     | SELECT $1, $2     | {1,2}      |   1
+ Planner          | Planner           |            |   2
+ ExecutorRun      | ExecutorRun       |            |   2
+ Result           | Result            |            |   3
+ Select query     | SELECT $1, $2, $3 | {1,2,3}    |   1
+ Planner          | Planner           |            |   2
+ ExecutorRun      | ExecutorRun       |            |   2
+ Result           | Result            |            |   3
 (13 rows)
 
 -- Test tracing only subset of individual statements with extended protocol
@@ -276,15 +276,15 @@ COMMIT;
 SELECT span_type, span_operation, parameters, lvl FROM peek_ordered_spans WHERE trace_id='00000000000000000000000000000003';
     span_type     |  span_operation   | parameters | lvl 
 ------------------+-------------------+------------+-----
- TransactionBlock | TransactionBlock  |            |   1
- Select query     | SELECT $1         | {1}        |   2
- Planner          | Planner           |            |   3
- ExecutorRun      | ExecutorRun       |            |   3
- Result           | Result            |            |   4
- Select query     | SELECT $1, $2, $3 | {1,2,3}    |   2
- Planner          | Planner           |            |   3
- ExecutorRun      | ExecutorRun       |            |   3
- Result           | Result            |            |   4
+ TransactionBlock | TransactionBlock  |            |   0
+ Select query     | SELECT $1         | {1}        |   1
+ Planner          | Planner           |            |   2
+ ExecutorRun      | ExecutorRun       |            |   2
+ Result           | Result            |            |   3
+ Select query     | SELECT $1, $2, $3 | {1,2,3}    |   1
+ Planner          | Planner           |            |   2
+ ExecutorRun      | ExecutorRun       |            |   2
+ Result           | Result            |            |   3
 (9 rows)
 
 -- Test tracing the whole transaction with extended protocol with BEGIN sent through extended protocol
@@ -299,15 +299,15 @@ COMMIT;
 SELECT span_type, span_operation, parameters, lvl FROM peek_ordered_spans WHERE trace_id='00000000000000000000000000000004';
     span_type     |  span_operation  | parameters | lvl 
 ------------------+------------------+------------+-----
- TransactionBlock | TransactionBlock |            |   1
- Utility query    | BEGIN;           |            |   2
- ProcessUtility   | ProcessUtility   |            |   3
- Select query     | SELECT $1        | {1}        |   2
- Planner          | Planner          |            |   3
- ExecutorRun      | ExecutorRun      |            |   3
- Result           | Result           |            |   4
- Utility query    | COMMIT;          |            |   2
- ProcessUtility   | ProcessUtility   |            |   3
+ TransactionBlock | TransactionBlock |            |   0
+ Utility query    | BEGIN;           |            |   1
+ ProcessUtility   | ProcessUtility   |            |   2
+ Select query     | SELECT $1        | {1}        |   1
+ Planner          | Planner          |            |   2
+ ExecutorRun      | ExecutorRun      |            |   2
+ Result           | Result           |            |   3
+ Utility query    | COMMIT;          |            |   1
+ ProcessUtility   | ProcessUtility   |            |   2
 (9 rows)
 
 -- Cleanup

--- a/expected/guc.out
+++ b/expected/guc.out
@@ -34,25 +34,25 @@ SELECT 3;
 select trace_id, span_operation, parameters, lvl from peek_ordered_spans;
              trace_id             |  span_operation  | parameters | lvl 
 ----------------------------------+------------------+------------+-----
- 00000000000000000000000000000004 | SELECT $1;       | {1}        |   1
- 00000000000000000000000000000004 | Planner          |            |   2
- 00000000000000000000000000000004 | ExecutorRun      |            |   2
- 00000000000000000000000000000004 | Result           |            |   3
- 00000000000000000000000000000004 | TransactionBlock |            |   1
- 00000000000000000000000000000005 | SELECT $1;       | {1}        |   2
- 00000000000000000000000000000005 | Planner          |            |   3
- 00000000000000000000000000000005 | ExecutorRun      |            |   3
- 00000000000000000000000000000005 | Result           |            |   4
- 00000000000000000000000000000005 | COMMIT;          |            |   2
- 00000000000000000000000000000005 | ProcessUtility   |            |   3
- fffffffffffffffffffffffffffffff5 | SELECT $1;       | {2}        |   1
- fffffffffffffffffffffffffffffff5 | Planner          |            |   2
- fffffffffffffffffffffffffffffff5 | ExecutorRun      |            |   2
- fffffffffffffffffffffffffffffff5 | Result           |            |   3
- fffffffffffffffffffffffffffffff5 | SELECT $1;       | {3}        |   1
- fffffffffffffffffffffffffffffff5 | Planner          |            |   2
- fffffffffffffffffffffffffffffff5 | ExecutorRun      |            |   2
- fffffffffffffffffffffffffffffff5 | Result           |            |   3
+ 00000000000000000000000000000004 | SELECT $1;       | {1}        |   0
+ 00000000000000000000000000000004 | Planner          |            |   1
+ 00000000000000000000000000000004 | ExecutorRun      |            |   1
+ 00000000000000000000000000000004 | Result           |            |   2
+ 00000000000000000000000000000004 | TransactionBlock |            |   0
+ 00000000000000000000000000000005 | SELECT $1;       | {1}        |   1
+ 00000000000000000000000000000005 | Planner          |            |   2
+ 00000000000000000000000000000005 | ExecutorRun      |            |   2
+ 00000000000000000000000000000005 | Result           |            |   3
+ 00000000000000000000000000000005 | COMMIT;          |            |   1
+ 00000000000000000000000000000005 | ProcessUtility   |            |   2
+ fffffffffffffffffffffffffffffff5 | SELECT $1;       | {2}        |   0
+ fffffffffffffffffffffffffffffff5 | Planner          |            |   1
+ fffffffffffffffffffffffffffffff5 | ExecutorRun      |            |   1
+ fffffffffffffffffffffffffffffff5 | Result           |            |   2
+ fffffffffffffffffffffffffffffff5 | SELECT $1;       | {3}        |   0
+ fffffffffffffffffffffffffffffff5 | Planner          |            |   1
+ fffffffffffffffffffffffffffffff5 | ExecutorRun      |            |   1
+ fffffffffffffffffffffffffffffff5 | Result           |            |   2
 (19 rows)
 
 CALL clean_spans();
@@ -86,22 +86,22 @@ SELECT 3;
 select trace_id, span_operation, parameters, lvl from peek_ordered_spans;
              trace_id             |   span_operation   | parameters | lvl 
 ----------------------------------+--------------------+------------+-----
- fffffffffffffffffffffffffffffff6 | SELECT $1;         | {2}        |   1
- fffffffffffffffffffffffffffffff6 | Planner            |            |   2
- fffffffffffffffffffffffffffffff6 | ExecutorRun        |            |   2
- fffffffffffffffffffffffffffffff6 | Result             |            |   3
- fffffffffffffffffffffffffffffff6 | SELECT $1, $2;     | {1,1}      |   1
- fffffffffffffffffffffffffffffff6 | Planner            |            |   2
- fffffffffffffffffffffffffffffff6 | ExecutorRun        |            |   2
- fffffffffffffffffffffffffffffff6 | Result             |            |   3
- fffffffffffffffffffffffffffffff6 | SELECT $1, $2, $3; | {1,2,3}    |   1
- fffffffffffffffffffffffffffffff6 | Planner            |            |   2
- fffffffffffffffffffffffffffffff6 | ExecutorRun        |            |   2
- fffffffffffffffffffffffffffffff6 | Result             |            |   3
- fffffffffffffffffffffffffffffff6 | SELECT $1;         | {3}        |   1
- fffffffffffffffffffffffffffffff6 | Planner            |            |   2
- fffffffffffffffffffffffffffffff6 | ExecutorRun        |            |   2
- fffffffffffffffffffffffffffffff6 | Result             |            |   3
+ fffffffffffffffffffffffffffffff6 | SELECT $1;         | {2}        |   0
+ fffffffffffffffffffffffffffffff6 | Planner            |            |   1
+ fffffffffffffffffffffffffffffff6 | ExecutorRun        |            |   1
+ fffffffffffffffffffffffffffffff6 | Result             |            |   2
+ fffffffffffffffffffffffffffffff6 | SELECT $1, $2;     | {1,1}      |   0
+ fffffffffffffffffffffffffffffff6 | Planner            |            |   1
+ fffffffffffffffffffffffffffffff6 | ExecutorRun        |            |   1
+ fffffffffffffffffffffffffffffff6 | Result             |            |   2
+ fffffffffffffffffffffffffffffff6 | SELECT $1, $2, $3; | {1,2,3}    |   0
+ fffffffffffffffffffffffffffffff6 | Planner            |            |   1
+ fffffffffffffffffffffffffffffff6 | ExecutorRun        |            |   1
+ fffffffffffffffffffffffffffffff6 | Result             |            |   2
+ fffffffffffffffffffffffffffffff6 | SELECT $1;         | {3}        |   0
+ fffffffffffffffffffffffffffffff6 | Planner            |            |   1
+ fffffffffffffffffffffffffffffff6 | ExecutorRun        |            |   1
+ fffffffffffffffffffffffffffffff6 | Result             |            |   2
 (16 rows)
 
 CALL clean_spans();

--- a/expected/insert.out
+++ b/expected/insert.out
@@ -5,11 +5,11 @@ SET pg_tracing.caller_sample_rate = 1.0;
 SELECT span_type, span_operation, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000001';
      span_type     |                                                          span_operation                                                           | lvl 
 -------------------+-----------------------------------------------------------------------------------------------------------------------------------+-----
- Utility query     | CREATE TABLE IF NOT EXISTS pg_tracing_test_table_with_constraint (a int, b char(20), CONSTRAINT PK_tracing_test PRIMARY KEY (a)); |   1
- ProcessUtility    | ProcessUtility                                                                                                                    |   2
- Utility query     | CREATE TABLE IF NOT EXISTS pg_tracing_test_table_with_constraint (a int, b char(20), CONSTRAINT PK_tracing_test PRIMARY KEY (a)); |   3
- ProcessUtility    | ProcessUtility                                                                                                                    |   4
- TransactionCommit | TransactionCommit                                                                                                                 |   1
+ Utility query     | CREATE TABLE IF NOT EXISTS pg_tracing_test_table_with_constraint (a int, b char(20), CONSTRAINT PK_tracing_test PRIMARY KEY (a)); |   0
+ ProcessUtility    | ProcessUtility                                                                                                                    |   1
+ Utility query     | CREATE TABLE IF NOT EXISTS pg_tracing_test_table_with_constraint (a int, b char(20), CONSTRAINT PK_tracing_test PRIMARY KEY (a)); |   2
+ ProcessUtility    | ProcessUtility                                                                                                                    |   3
+ TransactionCommit | TransactionCommit                                                                                                                 |   0
 (5 rows)
 
 -- Simple insertion
@@ -32,11 +32,11 @@ DETAIL:  Key (a)=(1) already exists.
 SELECT span_type, span_operation, sql_error_code, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000003';
   span_type   |                          span_operation                           | sql_error_code | lvl 
 --------------+-------------------------------------------------------------------+----------------+-----
- Insert query | INSERT INTO pg_tracing_test_table_with_constraint VALUES($1, $2); | 23505          |   1
- Planner      | Planner                                                           | 00000          |   2
- ExecutorRun  | ExecutorRun                                                       | 23505          |   2
- Insert       | Insert on pg_tracing_test_table_with_constraint                   | 23505          |   3
- Result       | Result                                                            | 23505          |   4
+ Insert query | INSERT INTO pg_tracing_test_table_with_constraint VALUES($1, $2); | 23505          |   0
+ Planner      | Planner                                                           | 00000          |   1
+ ExecutorRun  | ExecutorRun                                                       | 23505          |   1
+ Insert       | Insert on pg_tracing_test_table_with_constraint                   | 23505          |   2
+ Result       | Result                                                            | 23505          |   3
 (5 rows)
 
 -- Trigger an error while calling pg_tracing_peek_spans which resets tracing, nothing should be generated

--- a/expected/nested.out
+++ b/expected/nested.out
@@ -142,12 +142,12 @@ SET pg_tracing.track_utility=on;
 select span_operation, lvl FROM peek_ordered_spans where trace_id='00000000000000000000000000000054';
     span_operation     | lvl 
 -----------------------+-----
- CALL sum_one();       |   1
- ProcessUtility        |   2
- SELECT ($1 + $2)::int |   3
- Planner               |   4
- ExecutorRun           |   4
- Result                |   5
+ CALL sum_one();       |   0
+ ProcessUtility        |   1
+ SELECT ($1 + $2)::int |   2
+ Planner               |   3
+ ExecutorRun           |   3
+ Result                |   4
 (6 rows)
 
 -- Test again with utility tracking disabled
@@ -171,14 +171,14 @@ LANGUAGE sql IMMUTABLE;
 select span_operation, lvl FROM peek_ordered_spans where trace_id='00000000000000000000000000000056';
                    span_operation                   | lvl 
 ----------------------------------------------------+-----
- select test_immutable_function($1);                |   1
- Planner                                            |   2
- SELECT oid from pg_class where oid = a;            |   3
- Planner                                            |   4
- ExecutorRun                                        |   4
- IndexOnlyScan using pg_class_oid_index on pg_class |   5
- ExecutorRun                                        |   2
- Result                                             |   3
+ select test_immutable_function($1);                |   0
+ Planner                                            |   1
+ SELECT oid from pg_class where oid = a;            |   2
+ Planner                                            |   3
+ ExecutorRun                                        |   3
+ IndexOnlyScan using pg_class_oid_index on pg_class |   4
+ ExecutorRun                                        |   1
+ Result                                             |   2
 (8 rows)
 
 -- Create function with generate series
@@ -206,13 +206,13 @@ SELECT span_id AS span_result_id,
 select span_operation, lvl FROM peek_ordered_spans where trace_id='00000000000000000000000000000057';
                                      span_operation                                     | lvl 
 ----------------------------------------------------------------------------------------+-----
- select test_generate_series($1::int[]) FROM (VALUES ($2,$3)) as t;                     |   1
- Planner                                                                                |   2
- ExecutorRun                                                                            |   2
- ProjectSet                                                                             |   3
- Result                                                                                 |   4
- select * from pg_catalog.generate_series(array_lower($1, $2), array_upper($1, $3), $4) |   4
- Planner                                                                                |   5
+ select test_generate_series($1::int[]) FROM (VALUES ($2,$3)) as t;                     |   0
+ Planner                                                                                |   1
+ ExecutorRun                                                                            |   1
+ ProjectSet                                                                             |   2
+ Result                                                                                 |   3
+ select * from pg_catalog.generate_series(array_lower($1, $2), array_upper($1, $3), $4) |   3
+ Planner                                                                                |   4
 (7 rows)
 
 -- +-----------------------------------------------------------+
@@ -253,16 +253,16 @@ SELECT span_id AS span_e_id,
 select span_operation, lvl FROM peek_ordered_spans where trace_id='00000000000000000000000000000058';
                  span_operation                  | lvl 
 -------------------------------------------------+-----
- select test_function_result($1, $2);            |   1
- Planner                                         |   2
- ExecutorRun                                     |   2
- Result                                          |   3
- INSERT INTO pg_tracing_test(a, b) VALUES (a, b) |   4
- Planner                                         |   5
- ExecutorRun                                     |   5
- Insert on pg_tracing_test                       |   6
- Result                                          |   7
- TransactionCommit                               |   1
+ select test_function_result($1, $2);            |   0
+ Planner                                         |   1
+ ExecutorRun                                     |   1
+ Result                                          |   2
+ INSERT INTO pg_tracing_test(a, b) VALUES (a, b) |   3
+ Planner                                         |   4
+ ExecutorRun                                     |   4
+ Insert on pg_tracing_test                       |   5
+ Result                                          |   6
+ TransactionCommit                               |   0
 (10 rows)
 
 -- Make sure we have 2 query_id associated with the trace
@@ -281,18 +281,18 @@ SELECT count(distinct query_id)=2 from pg_tracing_consume_spans where trace_id='
 select span_operation, lvl FROM peek_ordered_spans where trace_id='00000000000000000000000000000059';
                    span_operation                   | lvl 
 ----------------------------------------------------+-----
- select * FROM test_2_nested_levels($1);            |   1
- Planner                                            |   2
- ExecutorRun                                        |   2
- FunctionScan on test_2_nested_levels               |   3
- SELECT * FROM test_function_project_set($1)        |   3
- Planner                                            |   4
- ExecutorRun                                        |   4
- FunctionScan on test_function_project_set          |   5
- SELECT oid from pg_class where oid = a             |   5
- Planner                                            |   6
- ExecutorRun                                        |   6
- IndexOnlyScan using pg_class_oid_index on pg_class |   7
+ select * FROM test_2_nested_levels($1);            |   0
+ Planner                                            |   1
+ ExecutorRun                                        |   1
+ FunctionScan on test_2_nested_levels               |   2
+ SELECT * FROM test_function_project_set($1)        |   2
+ Planner                                            |   3
+ ExecutorRun                                        |   3
+ FunctionScan on test_function_project_set          |   4
+ SELECT oid from pg_class where oid = a             |   4
+ Planner                                            |   5
+ ExecutorRun                                        |   5
+ IndexOnlyScan using pg_class_oid_index on pg_class |   6
 (12 rows)
 
 CALL clean_spans();

--- a/expected/nested_17.out
+++ b/expected/nested_17.out
@@ -10,17 +10,17 @@
 select span_operation, lvl FROM peek_ordered_spans where trace_id='00000000000000000000000000000001';
                             span_operation                            | lvl 
 ----------------------------------------------------------------------+-----
- SELECT eval_expr(format($1, $2, $3)), eval_expr(format($4, $5, $6)); |   1
- Planner                                                              |   2
- ExecutorRun                                                          |   2
- Result                                                               |   3
- $2||expr                                                             |   4
- Planner                                                              |   5
- Planner                                                              |   5
- select date $1 - interval $2                                         |   4
- Planner                                                              |   5
- ExecutorRun                                                          |   5
- Result                                                               |   6
+ SELECT eval_expr(format($1, $2, $3)), eval_expr(format($4, $5, $6)); |   0
+ Planner                                                              |   1
+ ExecutorRun                                                          |   1
+ Result                                                               |   2
+ $2||expr                                                             |   3
+ Planner                                                              |   4
+ Planner                                                              |   4
+ select date $1 - interval $2                                         |   3
+ Planner                                                              |   4
+ ExecutorRun                                                          |   4
+ Result                                                               |   5
 (11 rows)
 
 -- Cleanup

--- a/expected/parallel.out
+++ b/expected/parallel.out
@@ -80,17 +80,17 @@ set parallel_leader_participation=false;
 SELECT span_type, span_operation, lvl FROM peek_ordered_spans where trace_id='00000000000000000000000000000001' ORDER BY lvl, span_operation;
   span_type   |          span_operation           | lvl 
 --------------+-----------------------------------+-----
- Select query | select $1 from pg_class limit $2; |   1
- ExecutorRun  | ExecutorRun                       |   2
- Planner      | Planner                           |   2
- Limit        | Limit                             |   3
- Gather       | Gather                            |   4
- Select query | Worker 0                          |   5
- Select query | Worker 1                          |   5
- ExecutorRun  | ExecutorRun                       |   6
- ExecutorRun  | ExecutorRun                       |   6
- SeqScan      | SeqScan on pg_class               |   7
- SeqScan      | SeqScan on pg_class               |   7
+ Select query | select $1 from pg_class limit $2; |   0
+ ExecutorRun  | ExecutorRun                       |   1
+ Planner      | Planner                           |   1
+ Limit        | Limit                             |   2
+ Gather       | Gather                            |   3
+ Select query | Worker 0                          |   4
+ Select query | Worker 1                          |   4
+ ExecutorRun  | ExecutorRun                       |   5
+ ExecutorRun  | ExecutorRun                       |   5
+ SeqScan      | SeqScan on pg_class               |   6
+ SeqScan      | SeqScan on pg_class               |   6
 (11 rows)
 
 -- Cleanup

--- a/expected/parameters.out
+++ b/expected/parameters.out
@@ -9,10 +9,10 @@ SET pg_tracing.max_parameter_size=0;
 SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000001';
    span_operation   | parameters | lvl 
 --------------------+------------+-----
- select $1, $2, $3; |            |   1
- Planner            |            |   2
- ExecutorRun        |            |   2
- Result             |            |   3
+ select $1, $2, $3; |            |   0
+ Planner            |            |   1
+ ExecutorRun        |            |   1
+ Result             |            |   2
 (4 rows)
 
 -- Saturate the parameter buffer
@@ -26,10 +26,10 @@ SET pg_tracing.max_parameter_size=1;
 SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000002';
    span_operation   | parameters  | lvl 
 --------------------+-------------+-----
- select $1, $2, $3; | {1,...,...} |   1
- Planner            |             |   2
- ExecutorRun        |             |   2
- Result             |             |   3
+ select $1, $2, $3; | {1,...,...} |   0
+ Planner            |             |   1
+ ExecutorRun        |             |   1
+ Result             |             |   2
 (4 rows)
 
 SET pg_tracing.max_parameter_size=2;
@@ -42,10 +42,10 @@ SET pg_tracing.max_parameter_size=2;
 SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000003';
    span_operation   | parameters  | lvl 
 --------------------+-------------+-----
- select $1, $2, $3; | {1,...,...} |   1
- Planner            |             |   2
- ExecutorRun        |             |   2
- Result             |             |   3
+ select $1, $2, $3; | {1,...,...} |   0
+ Planner            |             |   1
+ ExecutorRun        |             |   1
+ Result             |             |   2
 (4 rows)
 
 SET pg_tracing.max_parameter_size=3;
@@ -58,10 +58,10 @@ SET pg_tracing.max_parameter_size=3;
 SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000004';
    span_operation   | parameters | lvl 
 --------------------+------------+-----
- select $1, $2, $3; | {1,2,...}  |   1
- Planner            |            |   2
- ExecutorRun        |            |   2
- Result             |            |   3
+ select $1, $2, $3; | {1,2,...}  |   0
+ Planner            |            |   1
+ ExecutorRun        |            |   1
+ Result             |            |   2
 (4 rows)
 
 SET pg_tracing.max_parameter_size=4;
@@ -74,10 +74,10 @@ SET pg_tracing.max_parameter_size=4;
 SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000005';
    span_operation   | parameters | lvl 
 --------------------+------------+-----
- select $1, $2, $3; | {1,2,...}  |   1
- Planner            |            |   2
- ExecutorRun        |            |   2
- Result             |            |   3
+ select $1, $2, $3; | {1,2,...}  |   0
+ Planner            |            |   1
+ ExecutorRun        |            |   1
+ Result             |            |   2
 (4 rows)
 
 SET pg_tracing.max_parameter_size=5;
@@ -90,10 +90,10 @@ SET pg_tracing.max_parameter_size=5;
 SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000006';
    span_operation   | parameters | lvl 
 --------------------+------------+-----
- select $1, $2, $3; | {1,2,3}    |   1
- Planner            |            |   2
- ExecutorRun        |            |   2
- Result             |            |   3
+ select $1, $2, $3; | {1,2,3}    |   0
+ Planner            |            |   1
+ ExecutorRun        |            |   1
+ Result             |            |   2
 (4 rows)
 
 CALL clean_spans();
@@ -108,10 +108,10 @@ SET pg_tracing.max_parameter_size=2;
 SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000001';
  span_operation | parameters | lvl 
 ----------------+------------+-----
- select $1;     | {'t...}    |   1
- Planner        |            |   2
- ExecutorRun    |            |   2
- Result         |            |   3
+ select $1;     | {'t...}    |   0
+ Planner        |            |   1
+ ExecutorRun    |            |   1
+ Result         |            |   2
 (4 rows)
 
 SET pg_tracing.max_parameter_size=19;
@@ -124,10 +124,10 @@ SET pg_tracing.max_parameter_size=19;
 SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000002';
  span_operation |        parameters        | lvl 
 ----------------+--------------------------+-----
- select $1;     | {'testtruncatedstrin...} |   1
- Planner        |                          |   2
- ExecutorRun    |                          |   2
- Result         |                          |   3
+ select $1;     | {'testtruncatedstrin...} |   0
+ Planner        |                          |   1
+ ExecutorRun    |                          |   1
+ Result         |                          |   2
 (4 rows)
 
 SET pg_tracing.max_parameter_size=20;
@@ -140,10 +140,10 @@ SET pg_tracing.max_parameter_size=20;
 SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000003';
  span_operation |        parameters         | lvl 
 ----------------+---------------------------+-----
- select $1;     | {'testtruncatedstring...} |   1
- Planner        |                           |   2
- ExecutorRun    |                           |   2
- Result         |                           |   3
+ select $1;     | {'testtruncatedstring...} |   0
+ Planner        |                           |   1
+ ExecutorRun    |                           |   1
+ Result         |                           |   2
 (4 rows)
 
 SET pg_tracing.max_parameter_size=21;
@@ -156,10 +156,10 @@ SET pg_tracing.max_parameter_size=21;
 SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000004';
  span_operation |       parameters        | lvl 
 ----------------+-------------------------+-----
- select $1;     | {'testtruncatedstring'} |   1
- Planner        |                         |   2
- ExecutorRun    |                         |   2
- Result         |                         |   3
+ select $1;     | {'testtruncatedstring'} |   0
+ Planner        |                         |   1
+ ExecutorRun    |                         |   1
+ Result         |                         |   2
 (4 rows)
 
 -- Cleanup

--- a/expected/parameters_16.out
+++ b/expected/parameters_16.out
@@ -9,10 +9,10 @@ SET pg_tracing.max_parameter_size=1;
 SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000001';
   span_operation   | parameters  | lvl 
 -------------------+-------------+-----
- select $1, $2, $3 | {1,...,...} |   1
- Planner           |             |   2
- ExecutorRun       |             |   2
- Result            |             |   3
+ select $1, $2, $3 | {1,...,...} |   0
+ Planner           |             |   1
+ ExecutorRun       |             |   1
+ Result            |             |   2
 (4 rows)
 
 SET pg_tracing.max_parameter_size=2;
@@ -25,10 +25,10 @@ SET pg_tracing.max_parameter_size=2;
 SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000002';
   span_operation   | parameters  | lvl 
 -------------------+-------------+-----
- select $1, $2, $3 | {1,...,...} |   1
- Planner           |             |   2
- ExecutorRun       |             |   2
- Result            |             |   3
+ select $1, $2, $3 | {1,...,...} |   0
+ Planner           |             |   1
+ ExecutorRun       |             |   1
+ Result            |             |   2
 (4 rows)
 
 SET pg_tracing.max_parameter_size=3;
@@ -41,10 +41,10 @@ SET pg_tracing.max_parameter_size=3;
 SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000003';
   span_operation   | parameters | lvl 
 -------------------+------------+-----
- select $1, $2, $3 | {1,2,...}  |   1
- Planner           |            |   2
- ExecutorRun       |            |   2
- Result            |            |   3
+ select $1, $2, $3 | {1,2,...}  |   0
+ Planner           |            |   1
+ ExecutorRun       |            |   1
+ Result            |            |   2
 (4 rows)
 
 -- Cleanup

--- a/expected/planstate.out
+++ b/expected/planstate.out
@@ -44,10 +44,10 @@ SET pg_tracing.deparse_plan=false;
 SELECT span_operation, deparse_info, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000003';
                    span_operation                    | deparse_info | parameters | lvl 
 -----------------------------------------------------+--------------+------------+-----
- SELECT * from pg_tracing_test where a=$1;           |              | {1}        |   1
- Planner                                             |              |            |   2
- ExecutorRun                                         |              |            |   2
- IndexScan using pg_tracing_index on pg_tracing_test |              |            |   3
+ SELECT * from pg_tracing_test where a=$1;           |              | {1}        |   0
+ Planner                                             |              |            |   1
+ ExecutorRun                                         |              |            |   1
+ IndexScan using pg_tracing_index on pg_tracing_test |              |            |   2
 (4 rows)
 
 -- Check generated spans when deparse is enabled
@@ -61,10 +61,10 @@ SET pg_tracing.deparse_plan=true;
 SELECT span_operation, deparse_info, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000004';
                    span_operation                    |    deparse_info     | parameters | lvl 
 -----------------------------------------------------+---------------------+------------+-----
- SELECT * from pg_tracing_test where a=$1;           |                     | {1}        |   1
- Planner                                             |                     |            |   2
- ExecutorRun                                         |                     |            |   2
- IndexScan using pg_tracing_index on pg_tracing_test | Index Cond: (a = 1) |            |   3
+ SELECT * from pg_tracing_test where a=$1;           |                     | {1}        |   0
+ Planner                                             |                     |            |   1
+ ExecutorRun                                         |                     |            |   1
+ IndexScan using pg_tracing_index on pg_tracing_test | Index Cond: (a = 1) |            |   2
 (4 rows)
 
 -- Clean created spans

--- a/expected/planstate_bitmap.out
+++ b/expected/planstate_bitmap.out
@@ -9,14 +9,14 @@
 SELECT span_operation, deparse_info, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000001';
                       span_operation                       |                 deparse_info                  | parameters | lvl 
 -----------------------------------------------------------+-----------------------------------------------+------------+-----
- SELECT * from pg_tracing_test where a=$1 OR a=$2 OR a=$3; |                                               | {1,2,3}    |   1
- Planner                                                   |                                               |            |   2
- ExecutorRun                                               |                                               |            |   2
- BitmapHeapScan on pg_tracing_test                         | Recheck Cond: ((a = 1) OR (a = 2) OR (a = 3)) |            |   3
- BitmapOr                                                  |                                               |            |   4
- BitmapIndexScan on pg_tracing_index                       | Index Cond: (a = 1)                           |            |   5
- BitmapIndexScan on pg_tracing_index                       | Index Cond: (a = 2)                           |            |   5
- BitmapIndexScan on pg_tracing_index                       | Index Cond: (a = 3)                           |            |   5
+ SELECT * from pg_tracing_test where a=$1 OR a=$2 OR a=$3; |                                               | {1,2,3}    |   0
+ Planner                                                   |                                               |            |   1
+ ExecutorRun                                               |                                               |            |   1
+ BitmapHeapScan on pg_tracing_test                         | Recheck Cond: ((a = 1) OR (a = 2) OR (a = 3)) |            |   2
+ BitmapOr                                                  |                                               |            |   3
+ BitmapIndexScan on pg_tracing_index                       | Index Cond: (a = 1)                           |            |   4
+ BitmapIndexScan on pg_tracing_index                       | Index Cond: (a = 2)                           |            |   4
+ BitmapIndexScan on pg_tracing_index                       | Index Cond: (a = 3)                           |            |   4
 (8 rows)
 
 --

--- a/expected/planstate_hash.out
+++ b/expected/planstate_hash.out
@@ -7,14 +7,14 @@
 SELECT span_operation, deparse_info, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000001';
                               span_operation                              |    deparse_info    | parameters | lvl 
 --------------------------------------------------------------------------+--------------------+------------+-----
- select count(*) from pg_tracing_test r join pg_tracing_test s using (a); |                    |            |   1
- Planner                                                                  |                    |            |   2
- ExecutorRun                                                              |                    |            |   2
- Aggregate                                                                |                    |            |   3
- Hash Join                                                                | Hash Cond: (a = a) |            |   4
- SeqScan on pg_tracing_test r                                             |                    |            |   5
- Hash                                                                     |                    |            |   5
- SeqScan on pg_tracing_test s                                             |                    |            |   6
+ select count(*) from pg_tracing_test r join pg_tracing_test s using (a); |                    |            |   0
+ Planner                                                                  |                    |            |   1
+ ExecutorRun                                                              |                    |            |   1
+ Aggregate                                                                |                    |            |   2
+ Hash Join                                                                | Hash Cond: (a = a) |            |   3
+ SeqScan on pg_tracing_test r                                             |                    |            |   4
+ Hash                                                                     |                    |            |   4
+ SeqScan on pg_tracing_test s                                             |                    |            |   5
 (8 rows)
 
 -- +-----------------------------------------+

--- a/expected/planstate_projectset.out
+++ b/expected/planstate_projectset.out
@@ -9,13 +9,13 @@
 SELECT span_operation, deparse_info, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000001';
                                                                                               span_operation                                                                                              | deparse_info |  parameters   | lvl 
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------+---------------+-----
- select information_schema._pg_expandarray($1::int[]);                                                                                                                                                    |              | {"'{0,1,2}'"} |   1
- Planner                                                                                                                                                                                                  |              |               |   2
- ExecutorRun                                                                                                                                                                                              |              |               |   2
- ProjectSet                                                                                                                                                                                               |              |               |   3
- Result                                                                                                                                                                                                   |              |               |   4
- select $1[s], s operator(pg_catalog.-) pg_catalog.array_lower($1,$2) operator(pg_catalog.+) $3 from pg_catalog.generate_series(pg_catalog.array_lower($1,$4), pg_catalog.array_upper($1,$5), $6) as g(s) |              | {1,1,1,1,1}   |   4
- Planner                                                                                                                                                                                                  |              |               |   5
+ select information_schema._pg_expandarray($1::int[]);                                                                                                                                                    |              | {"'{0,1,2}'"} |   0
+ Planner                                                                                                                                                                                                  |              |               |   1
+ ExecutorRun                                                                                                                                                                                              |              |               |   1
+ ProjectSet                                                                                                                                                                                               |              |               |   2
+ Result                                                                                                                                                                                                   |              |               |   3
+ select $1[s], s operator(pg_catalog.-) pg_catalog.array_lower($1,$2) operator(pg_catalog.+) $3 from pg_catalog.generate_series(pg_catalog.array_lower($1,$4), pg_catalog.array_upper($1,$5), $6) as g(s) |              | {1,1,1,1,1}   |   3
+ Planner                                                                                                                                                                                                  |              |               |   4
 (7 rows)
 
 -- +---------------------------------------------+

--- a/expected/planstate_projectset_17.out
+++ b/expected/planstate_projectset_17.out
@@ -9,13 +9,13 @@
 SELECT span_operation, deparse_info, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000001';
                     span_operation                     | deparse_info |  parameters   | lvl 
 -------------------------------------------------------+--------------+---------------+-----
- select information_schema._pg_expandarray($1::int[]); |              | {"'{0,1,2}'"} |   1
- Planner                                               |              |               |   2
- ExecutorRun                                           |              |               |   2
- ProjectSet                                            |              |               |   3
- Result                                                |              |               |   4
- SELECT * FROM pg_catalog.unnest($1) WITH ORDINALITY   |              |               |   4
- Planner                                               |              |               |   5
+ select information_schema._pg_expandarray($1::int[]); |              | {"'{0,1,2}'"} |   0
+ Planner                                               |              |               |   1
+ ExecutorRun                                           |              |               |   1
+ ProjectSet                                            |              |               |   2
+ Result                                                |              |               |   3
+ SELECT * FROM pg_catalog.unnest($1) WITH ORDINALITY   |              |               |   3
+ Planner                                               |              |               |   4
 (7 rows)
 
 -- +---------------------------------------------+

--- a/expected/planstate_subplans.out
+++ b/expected/planstate_subplans.out
@@ -4,17 +4,17 @@ MERGE INTO m USING (select 1 k, 'merge source InitPlan' v offset 0) o ON m.k=o.k
 WHEN MATCHED THEN UPDATE SET v = (SELECT b || ' merge update' FROM cte_init WHERE a = 1 LIMIT 1)
 WHEN NOT MATCHED THEN INSERT VALUES(o.k, o.v);
 -- Check generated spans for init plan
-SELECT span_operation, deparse_info, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000001' AND lvl < 4;
+SELECT span_operation, deparse_info, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000001' AND lvl < 3;
                                     span_operation                                     | deparse_info |                                parameters                                | lvl 
 ---------------------------------------------------------------------------------------+--------------+--------------------------------------------------------------------------+-----
- WITH cte_init AS MATERIALIZED (SELECT $1 a, $2 b)                                    +|              | {1,"'cte_init val'",1,"'merge source InitPlan'",0,"' merge update'",1,1} |   1
+ WITH cte_init AS MATERIALIZED (SELECT $1 a, $2 b)                                    +|              | {1,"'cte_init val'",1,"'merge source InitPlan'",0,"' merge update'",1,1} |   0
  MERGE INTO m USING (select $3 k, $4 v offset $5) o ON m.k=o.k                        +|              |                                                                          | 
  WHEN MATCHED THEN UPDATE SET v = (SELECT b || $6 FROM cte_init WHERE a = $7 LIMIT $8)+|              |                                                                          | 
  WHEN NOT MATCHED THEN INSERT VALUES(o.k, o.v);                                        |              |                                                                          | 
- Planner                                                                               |              |                                                                          |   2
- ExecutorRun                                                                           |              |                                                                          |   2
- Merge on m                                                                            |              |                                                                          |   3
- TransactionCommit                                                                     |              |                                                                          |   1
+ Planner                                                                               |              |                                                                          |   1
+ ExecutorRun                                                                           |              |                                                                          |   1
+ Merge on m                                                                            |              |                                                                          |   2
+ TransactionCommit                                                                     |              |                                                                          |   0
 (5 rows)
 
 -- +----------------------------------------------------------+

--- a/expected/planstate_union.out
+++ b/expected/planstate_union.out
@@ -12,16 +12,16 @@ SELECT count(*) FROM pg_tracing_test WHERE a + 0 < 10000;
 SELECT span_operation, deparse_info, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000001';
                      span_operation                      |        deparse_info        |   parameters   | lvl 
 ---------------------------------------------------------+----------------------------+----------------+-----
- SELECT count(*) FROM pg_tracing_test WHERE a + $1 < $2 +|                            | {0,10,0,10000} |   1
+ SELECT count(*) FROM pg_tracing_test WHERE a + $1 < $2 +|                            | {0,10,0,10000} |   0
  UNION ALL                                              +|                            |                | 
  SELECT count(*) FROM pg_tracing_test WHERE a + $3 < $4; |                            |                | 
- Planner                                                 |                            |                |   2
- ExecutorRun                                             |                            |                |   2
- Append                                                  |                            |                |   3
- Aggregate                                               |                            |                |   4
- SeqScan on pg_tracing_test                              | Filter : ((a + 0) < 10)    |                |   5
- Aggregate                                               |                            |                |   4
- SeqScan on pg_tracing_test pg_tracing_test_1            | Filter : ((a + 0) < 10000) |                |   5
+ Planner                                                 |                            |                |   1
+ ExecutorRun                                             |                            |                |   1
+ Append                                                  |                            |                |   2
+ Aggregate                                               |                            |                |   3
+ SeqScan on pg_tracing_test                              | Filter : ((a + 0) < 10)    |                |   4
+ Aggregate                                               |                            |                |   3
+ SeqScan on pg_tracing_test pg_tracing_test_1            | Filter : ((a + 0) < 10000) |                |   4
 (8 rows)
 
 -- +------------------------------------------+

--- a/expected/psql_extended.out
+++ b/expected/psql_extended.out
@@ -9,11 +9,11 @@
 SELECT trace_id, span_type, span_operation, parameters, lvl FROM peek_ordered_spans;
              trace_id             |  span_type   | span_operation | parameters | lvl 
 ----------------------------------+--------------+----------------+------------+-----
- 00000000000000000000000000000001 | Select query | SELECT $1, $2  |            |   1
- 00000000000000000000000000000001 | Select query | SELECT $1, $2  | {1,2}      |   1
- 00000000000000000000000000000001 | Planner      | Planner        |            |   2
- 00000000000000000000000000000001 | ExecutorRun  | ExecutorRun    |            |   2
- 00000000000000000000000000000001 | Result       | Result         |            |   3
+ 00000000000000000000000000000001 | Select query | SELECT $1, $2  |            |   0
+ 00000000000000000000000000000001 | Select query | SELECT $1, $2  | {1,2}      |   0
+ 00000000000000000000000000000001 | Planner      | Planner        |            |   1
+ 00000000000000000000000000000001 | ExecutorRun  | ExecutorRun    |            |   1
+ 00000000000000000000000000000001 | Result       | Result         |            |   2
 (5 rows)
 
 WITH max_end AS (select max(span_end) from pg_tracing_peek_spans)

--- a/expected/psql_extended_tx.out
+++ b/expected/psql_extended_tx.out
@@ -25,19 +25,19 @@ COMMIT;
 SELECT trace_id, span_type, span_operation, parameters, lvl FROM peek_ordered_spans;
              trace_id             |    span_type     |  span_operation   | parameters | lvl 
 ----------------------------------+------------------+-------------------+------------+-----
- 00000000000000000000000000000002 | TransactionBlock | TransactionBlock  |            |   1
- 00000000000000000000000000000002 | Select query     | select $1         | {1}        |   2
- 00000000000000000000000000000002 | Planner          | Planner           |            |   3
- 00000000000000000000000000000002 | ExecutorRun      | ExecutorRun       |            |   3
- 00000000000000000000000000000002 | Result           | Result            |            |   4
- 00000000000000000000000000000003 | Select query     | select $1, $2     | {1,2}      |   2
- 00000000000000000000000000000003 | Planner          | Planner           |            |   3
- 00000000000000000000000000000003 | ExecutorRun      | ExecutorRun       |            |   3
- 00000000000000000000000000000003 | Result           | Result            |            |   4
- 00000000000000000000000000000004 | Select query     | select $1, $2, $3 | {1,2,3}    |   2
- 00000000000000000000000000000004 | Planner          | Planner           |            |   3
- 00000000000000000000000000000004 | ExecutorRun      | ExecutorRun       |            |   3
- 00000000000000000000000000000004 | Result           | Result            |            |   4
+ 00000000000000000000000000000002 | TransactionBlock | TransactionBlock  |            |   0
+ 00000000000000000000000000000002 | Select query     | select $1         | {1}        |   1
+ 00000000000000000000000000000002 | Planner          | Planner           |            |   2
+ 00000000000000000000000000000002 | ExecutorRun      | ExecutorRun       |            |   2
+ 00000000000000000000000000000002 | Result           | Result            |            |   3
+ 00000000000000000000000000000003 | Select query     | select $1, $2     | {1,2}      |   1
+ 00000000000000000000000000000003 | Planner          | Planner           |            |   2
+ 00000000000000000000000000000003 | ExecutorRun      | ExecutorRun       |            |   2
+ 00000000000000000000000000000003 | Result           | Result            |            |   3
+ 00000000000000000000000000000004 | Select query     | select $1, $2, $3 | {1,2,3}    |   1
+ 00000000000000000000000000000004 | Planner          | Planner           |            |   2
+ 00000000000000000000000000000004 | ExecutorRun      | ExecutorRun       |            |   2
+ 00000000000000000000000000000004 | Result           | Result            |            |   3
 (13 rows)
 
 CALL clean_spans();
@@ -68,23 +68,23 @@ COMMIT;
 SELECT trace_id, span_type, span_operation, parameters, lvl FROM peek_ordered_spans;
              trace_id             |    span_type     |  span_operation   | parameters | lvl 
 ----------------------------------+------------------+-------------------+------------+-----
- 00000000000000000000000000000005 | TransactionBlock | TransactionBlock  |            |   1
- 00000000000000000000000000000005 | Utility query    | BEGIN;            |            |   2
- 00000000000000000000000000000005 | ProcessUtility   | ProcessUtility    |            |   3
- 00000000000000000000000000000005 | Select query     | select $1         | {1}        |   2
- 00000000000000000000000000000005 | Planner          | Planner           |            |   3
- 00000000000000000000000000000005 | ExecutorRun      | ExecutorRun       |            |   3
- 00000000000000000000000000000005 | Result           | Result            |            |   4
- 00000000000000000000000000000005 | Select query     | select $1, $2     | {1,2}      |   2
- 00000000000000000000000000000005 | Planner          | Planner           |            |   3
- 00000000000000000000000000000005 | ExecutorRun      | ExecutorRun       |            |   3
- 00000000000000000000000000000005 | Result           | Result            |            |   4
- 00000000000000000000000000000005 | Select query     | select $1, $2, $3 | {1,2,3}    |   2
- 00000000000000000000000000000005 | Planner          | Planner           |            |   3
- 00000000000000000000000000000005 | ExecutorRun      | ExecutorRun       |            |   3
- 00000000000000000000000000000005 | Result           | Result            |            |   4
- 00000000000000000000000000000005 | Utility query    | COMMIT;           |            |   2
- 00000000000000000000000000000005 | ProcessUtility   | ProcessUtility    |            |   3
+ 00000000000000000000000000000005 | TransactionBlock | TransactionBlock  |            |   0
+ 00000000000000000000000000000005 | Utility query    | BEGIN;            |            |   1
+ 00000000000000000000000000000005 | ProcessUtility   | ProcessUtility    |            |   2
+ 00000000000000000000000000000005 | Select query     | select $1         | {1}        |   1
+ 00000000000000000000000000000005 | Planner          | Planner           |            |   2
+ 00000000000000000000000000000005 | ExecutorRun      | ExecutorRun       |            |   2
+ 00000000000000000000000000000005 | Result           | Result            |            |   3
+ 00000000000000000000000000000005 | Select query     | select $1, $2     | {1,2}      |   1
+ 00000000000000000000000000000005 | Planner          | Planner           |            |   2
+ 00000000000000000000000000000005 | ExecutorRun      | ExecutorRun       |            |   2
+ 00000000000000000000000000000005 | Result           | Result            |            |   3
+ 00000000000000000000000000000005 | Select query     | select $1, $2, $3 | {1,2,3}    |   1
+ 00000000000000000000000000000005 | Planner          | Planner           |            |   2
+ 00000000000000000000000000000005 | ExecutorRun      | ExecutorRun       |            |   2
+ 00000000000000000000000000000005 | Result           | Result            |            |   3
+ 00000000000000000000000000000005 | Utility query    | COMMIT;           |            |   1
+ 00000000000000000000000000000005 | ProcessUtility   | ProcessUtility    |            |   2
 (17 rows)
 
 CALL clean_spans();
@@ -111,13 +111,19 @@ SELECT span_type, span_operation, parameters, lvl FROM peek_ordered_spans
     where trace_id='00000000000000000000000000000006' AND lvl <= 2;
     span_type     |  span_operation  | parameters | lvl 
 ------------------+------------------+------------+-----
+ Utility query    | BEGIN            |            |   0
+ TransactionBlock | TransactionBlock |            |   0
  Utility query    | BEGIN            |            |   1
- TransactionBlock | TransactionBlock |            |   1
- Utility query    | BEGIN            |            |   2
- Select query     | SELECT $1        | {1}        |   2
- Select query     | SELECT $1, $2    | {1,2}      |   2
- Utility query    | COMMIT           |            |   2
-(6 rows)
+ ProcessUtility   | ProcessUtility   |            |   2
+ Select query     | SELECT $1        | {1}        |   1
+ Planner          | Planner          |            |   2
+ ExecutorRun      | ExecutorRun      |            |   2
+ Select query     | SELECT $1, $2    | {1,2}      |   1
+ Planner          | Planner          |            |   2
+ ExecutorRun      | ExecutorRun      |            |   2
+ Utility query    | COMMIT           |            |   1
+ ProcessUtility   | ProcessUtility   |            |   2
+(12 rows)
 
 SELECT get_epoch(span_end) as span_select_1_end
 	from pg_tracing_peek_spans where span_operation='SELECT $1' and trace_id='00000000000000000000000000000006' \gset
@@ -159,21 +165,21 @@ SELECT 1, 2, 3 \parse stmt_mix_3
 SELECT span_type, span_operation, parameters, lvl FROM peek_ordered_spans;
     span_type     |  span_operation   | parameters | lvl 
 ------------------+-------------------+------------+-----
- TransactionBlock | TransactionBlock  |            |   1
- Utility query    | BEGIN;            |            |   2
- ProcessUtility   | ProcessUtility    |            |   3
- Select query     | SELECT 1          |            |   2
- ExecutorRun      | ExecutorRun       |            |   3
- Result           | Result            |            |   4
- Select query     | SELECT 1, 2       |            |   2
- ExecutorRun      | ExecutorRun       |            |   3
- Result           | Result            |            |   4
- Select query     | SELECT $1, $2, $3 | {1,2,3}    |   2
- Planner          | Planner           |            |   3
- ExecutorRun      | ExecutorRun       |            |   3
- Result           | Result            |            |   4
- Utility query    | COMMIT            |            |   2
- ProcessUtility   | ProcessUtility    |            |   3
+ TransactionBlock | TransactionBlock  |            |   0
+ Utility query    | BEGIN;            |            |   1
+ ProcessUtility   | ProcessUtility    |            |   2
+ Select query     | SELECT 1          |            |   1
+ ExecutorRun      | ExecutorRun       |            |   2
+ Result           | Result            |            |   3
+ Select query     | SELECT 1, 2       |            |   1
+ ExecutorRun      | ExecutorRun       |            |   2
+ Result           | Result            |            |   3
+ Select query     | SELECT $1, $2, $3 | {1,2,3}    |   1
+ Planner          | Planner           |            |   2
+ ExecutorRun      | ExecutorRun       |            |   2
+ Result           | Result            |            |   3
+ Utility query    | COMMIT            |            |   1
+ ProcessUtility   | ProcessUtility    |            |   2
 (15 rows)
 
 SELECT get_epoch(span_end) as span_select_1_end
@@ -220,13 +226,19 @@ SELECT span_type, span_operation, parameters, lvl FROM peek_ordered_spans
     WHERE lvl <= 2;
     span_type     |  span_operation  | parameters | lvl 
 ------------------+------------------+------------+-----
+ Utility query    | BEGIN            |            |   0
+ TransactionBlock | TransactionBlock |            |   0
  Utility query    | BEGIN            |            |   1
- TransactionBlock | TransactionBlock |            |   1
- Utility query    | BEGIN            |            |   2
- Select query     | SELECT $1        | {1}        |   2
- Select query     | SELECT $1, $2    | {1,2}      |   2
- Utility query    | COMMIT           |            |   2
-(6 rows)
+ ProcessUtility   | ProcessUtility   |            |   2
+ Select query     | SELECT $1        | {1}        |   1
+ Planner          | Planner          |            |   2
+ ExecutorRun      | ExecutorRun      |            |   2
+ Select query     | SELECT $1, $2    | {1,2}      |   1
+ Planner          | Planner          |            |   2
+ ExecutorRun      | ExecutorRun      |            |   2
+ Utility query    | COMMIT           |            |   1
+ ProcessUtility   | ProcessUtility   |            |   2
+(12 rows)
 
 SELECT get_epoch(span_end) as span_select_1_end
 	from pg_tracing_peek_spans where span_operation='SELECT $1' \gset

--- a/expected/sample.out
+++ b/expected/sample.out
@@ -65,22 +65,22 @@ select count(distinct(trace_id)) from pg_tracing_peek_spans;
 select span_operation, parameters, lvl from peek_ordered_spans;
  span_operation | parameters | lvl 
 ----------------+------------+-----
- SELECT $1;     | {1}        |   1
- Planner        |            |   2
- ExecutorRun    |            |   2
- Result         |            |   3
- SELECT $1;     | {2}        |   1
- Planner        |            |   2
- ExecutorRun    |            |   2
- Result         |            |   3
- SELECT $1;     | {3}        |   1
- Planner        |            |   2
- ExecutorRun    |            |   2
- Result         |            |   3
- SELECT $1;     | {4}        |   1
- Planner        |            |   2
- ExecutorRun    |            |   2
- Result         |            |   3
+ SELECT $1;     | {1}        |   0
+ Planner        |            |   1
+ ExecutorRun    |            |   1
+ Result         |            |   2
+ SELECT $1;     | {2}        |   0
+ Planner        |            |   1
+ ExecutorRun    |            |   1
+ Result         |            |   2
+ SELECT $1;     | {3}        |   0
+ Planner        |            |   1
+ ExecutorRun    |            |   1
+ Result         |            |   2
+ SELECT $1;     | {4}        |   0
+ Planner        |            |   1
+ ExecutorRun    |            |   1
+ Result         |            |   2
 (16 rows)
 
 -- Top spans should reuse generated ids and have trace_id = parent_id
@@ -143,18 +143,18 @@ select distinct(trace_id) from pg_tracing_peek_spans order by trace_id;
 select span_operation, parameters, lvl from peek_ordered_spans;
  span_operation | parameters | lvl 
 ----------------+------------+-----
- SELECT $1;     | {1}        |   1
- Planner        |            |   2
- ExecutorRun    |            |   2
- Result         |            |   3
- SELECT $1;     | {3}        |   1
- Planner        |            |   2
- ExecutorRun    |            |   2
- Result         |            |   3
- SELECT $1;     | {4}        |   1
- Planner        |            |   2
- ExecutorRun    |            |   2
- Result         |            |   3
+ SELECT $1;     | {1}        |   0
+ Planner        |            |   1
+ ExecutorRun    |            |   1
+ Result         |            |   2
+ SELECT $1;     | {3}        |   0
+ Planner        |            |   1
+ ExecutorRun    |            |   1
+ Result         |            |   2
+ SELECT $1;     | {4}        |   0
+ Planner        |            |   1
+ ExecutorRun    |            |   1
+ Result         |            |   2
 (12 rows)
 
 -- Cleaning

--- a/expected/select.out
+++ b/expected/select.out
@@ -68,11 +68,11 @@ SELECT processed_traces from pg_tracing_info \gset
 SELECT span_type, span_operation, lvl FROM peek_ordered_spans where trace_id='00000000000000000000000000000003';
   span_type   |              span_operation              | lvl 
 --------------+------------------------------------------+-----
- Select query | SELECT count(*) from current_database(); |   1
- Planner      | Planner                                  |   2
- ExecutorRun  | ExecutorRun                              |   2
- Aggregate    | Aggregate                                |   3
- FunctionScan | FunctionScan on current_database         |   4
+ Select query | SELECT count(*) from current_database(); |   0
+ Planner      | Planner                                  |   1
+ ExecutorRun  | ExecutorRun                              |   1
+ Aggregate    | Aggregate                                |   2
+ FunctionScan | FunctionScan on current_database         |   3
 (5 rows)
 
 -- Check expected reported number of trace
@@ -92,13 +92,13 @@ FROM (SELECT
 SELECT span_type, span_operation, lvl FROM peek_ordered_spans where trace_id='00000000000000000000000000000004';
   span_type   |                                                       span_operation                                                       | lvl 
 --------------+----------------------------------------------------------------------------------------------------------------------------+-----
- Select query | SELECT s.relation_size + s.index_size as relation_size                                                                    +|   1
+ Select query | SELECT s.relation_size + s.index_size as relation_size                                                                    +|   0
               | FROM (SELECT pg_relation_size(C.oid) as relation_size, pg_indexes_size(C.oid) as index_size FROM pg_class C) as s limit $1 | 
- Planner      | Planner                                                                                                                    |   2
- ExecutorRun  | ExecutorRun                                                                                                                |   2
- Limit        | Limit                                                                                                                      |   3
- SubqueryScan | SubqueryScan on s                                                                                                          |   4
- SeqScan      | SeqScan on pg_class c                                                                                                      |   5
+ Planner      | Planner                                                                                                                    |   1
+ ExecutorRun  | ExecutorRun                                                                                                                |   1
+ Limit        | Limit                                                                                                                      |   2
+ SubqueryScan | SubqueryScan on s                                                                                                          |   3
+ SeqScan      | SeqScan on pg_class c                                                                                                      |   4
 (6 rows)
 
 -- Check that we're in a correct state after a timeout
@@ -109,10 +109,10 @@ ERROR:  canceling statement due to statement timeout
 SELECT span_type, span_operation, sql_error_code, lvl FROM peek_ordered_spans where trace_id='00000000000000000000000000000007';
   span_type   |       span_operation        | sql_error_code | lvl 
 --------------+-----------------------------+----------------+-----
- Select query | select * from pg_sleep($1); | 57014          |   1
- Planner      | Planner                     | 00000          |   2
- ExecutorRun  | ExecutorRun                 | 57014          |   2
- FunctionScan | FunctionScan on pg_sleep    | 57014          |   3
+ Select query | select * from pg_sleep($1); | 57014          |   0
+ Planner      | Planner                     | 00000          |   1
+ ExecutorRun  | ExecutorRun                 | 57014          |   1
+ FunctionScan | FunctionScan on pg_sleep    | 57014          |   2
 (4 rows)
 
 -- Cleanup statement setting
@@ -128,10 +128,10 @@ set statement_timeout=0;
 SELECT span_type, span_operation, sql_error_code, lvl FROM peek_ordered_spans where trace_id='00000000000000000000000000000008';
   span_type   | span_operation | sql_error_code | lvl 
 --------------+----------------+----------------+-----
- Select query | select $1;     | 00000          |   1
- Planner      | Planner        | 00000          |   2
- ExecutorRun  | ExecutorRun    | 00000          |   2
- Result       | Result         | 00000          |   3
+ Select query | select $1;     | 00000          |   0
+ Planner      | Planner        | 00000          |   1
+ ExecutorRun  | ExecutorRun    | 00000          |   1
+ Result       | Result         | 00000          |   2
 (4 rows)
 
 -- Cleanup
@@ -145,10 +145,10 @@ SET plan_cache_mode='auto';
 SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='0000000000000000000000000000000b';
    span_operation    | parameters | lvl 
 ---------------------+------------+-----
- select $1 limit $2; | {1,0}      |   1
- Planner             |            |   2
- ExecutorRun         |            |   2
- Limit               |            |   3
+ select $1 limit $2; | {1,0}      |   0
+ Planner             |            |   1
+ ExecutorRun         |            |   1
+ Limit               |            |   2
 (4 rows)
 
 -- Test multiple statements in a single query
@@ -166,10 +166,10 @@ SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='0
 SELECT span_operation, parameters, lvl from peek_ordered_spans where trace_id='0000000000000000000000000000000c';
  span_operation | parameters | lvl 
 ----------------+------------+-----
- select $1;     | {1}        |   1
- Planner        |            |   2
- ExecutorRun    |            |   2
- Result         |            |   3
+ select $1;     | {1}        |   0
+ Planner        |            |   1
+ ExecutorRun    |            |   1
+ Result         |            |   2
 (4 rows)
 
 -- Check multi statement query
@@ -190,14 +190,14 @@ SELECT 1\; SELECT 1, 2;
 SELECT span_type, span_operation, parameters, lvl from peek_ordered_spans;
   span_type   | span_operation | parameters | lvl 
 --------------+----------------+------------+-----
- Select query | SELECT $1;     | {1}        |   1
- Planner      | Planner        |            |   2
- ExecutorRun  | ExecutorRun    |            |   2
- Result       | Result         |            |   3
- Select query | SELECT $1, $2; | {1,2}      |   1
- Planner      | Planner        |            |   2
- ExecutorRun  | ExecutorRun    |            |   2
- Result       | Result         |            |   3
+ Select query | SELECT $1;     | {1}        |   0
+ Planner      | Planner        |            |   1
+ ExecutorRun  | ExecutorRun    |            |   1
+ Result       | Result         |            |   2
+ Select query | SELECT $1, $2; | {1,2}      |   0
+ Planner      | Planner        |            |   1
+ ExecutorRun  | ExecutorRun    |            |   1
+ Result       | Result         |            |   2
 (8 rows)
 
 CALL clean_spans();
@@ -225,8 +225,8 @@ ERROR:  invalid input syntax for type integer: "\xdeadbeef"
 SELECT span_type, span_operation, parameters, sql_error_code, lvl from peek_ordered_spans;
   span_type   |        span_operation        |    parameters     | sql_error_code | lvl 
 --------------+------------------------------+-------------------+----------------+-----
- Select query | SELECT $1::bytea::text::int; | {"'\\xDEADBEEF'"} | 22P02          |   1
- Planner      | Planner                      |                   | 22P02          |   2
+ Select query | SELECT $1::bytea::text::int; | {"'\\xDEADBEEF'"} | 22P02          |   0
+ Planner      | Planner                      |                   | 22P02          |   1
 (2 rows)
 
 CALL clean_spans();
@@ -247,16 +247,16 @@ SELECT lazy_function('{1,2,3,4}'::int[]) FROM (VALUES (1,2)) as t;
 SELECT span_type, span_operation, parameters, lvl from peek_ordered_spans;
      span_type     |                                                                                             span_operation                                                                                              |     parameters      | lvl 
 -------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------+-----
- Utility query     | CREATE OR REPLACE FUNCTION lazy_function(IN anyarray, OUT x anyelement) RETURNS SETOF anyelement LANGUAGE sql AS 'select * from pg_catalog.generate_series(array_lower($1, 1), array_upper($1, 1), 1)'; |                     |   1
- ProcessUtility    | ProcessUtility                                                                                                                                                                                          |                     |   2
- TransactionCommit | TransactionCommit                                                                                                                                                                                       |                     |   1
- Select query      | SELECT lazy_function($1::int[]) FROM (VALUES ($2,$3)) as t;                                                                                                                                             | {"'{1,2,3,4}'",1,2} |   1
- Planner           | Planner                                                                                                                                                                                                 |                     |   2
- ExecutorRun       | ExecutorRun                                                                                                                                                                                             |                     |   2
- ProjectSet        | ProjectSet                                                                                                                                                                                              |                     |   3
- Result            | Result                                                                                                                                                                                                  |                     |   4
- Select query      | select * from pg_catalog.generate_series(array_lower($1, $2), array_upper($1, $3), $4)                                                                                                                  | {1,1,1}             |   4
- Planner           | Planner                                                                                                                                                                                                 |                     |   5
+ Utility query     | CREATE OR REPLACE FUNCTION lazy_function(IN anyarray, OUT x anyelement) RETURNS SETOF anyelement LANGUAGE sql AS 'select * from pg_catalog.generate_series(array_lower($1, 1), array_upper($1, 1), 1)'; |                     |   0
+ ProcessUtility    | ProcessUtility                                                                                                                                                                                          |                     |   1
+ TransactionCommit | TransactionCommit                                                                                                                                                                                       |                     |   0
+ Select query      | SELECT lazy_function($1::int[]) FROM (VALUES ($2,$3)) as t;                                                                                                                                             | {"'{1,2,3,4}'",1,2} |   0
+ Planner           | Planner                                                                                                                                                                                                 |                     |   1
+ ExecutorRun       | ExecutorRun                                                                                                                                                                                             |                     |   1
+ ProjectSet        | ProjectSet                                                                                                                                                                                              |                     |   2
+ Result            | Result                                                                                                                                                                                                  |                     |   3
+ Select query      | select * from pg_catalog.generate_series(array_lower($1, $2), array_upper($1, $3), $4)                                                                                                                  | {1,1,1}             |   3
+ Planner           | Planner                                                                                                                                                                                                 |                     |   4
 (10 rows)
 
 CALL clean_spans();
@@ -270,18 +270,18 @@ SELECT information_schema._pg_truetypid(a, t) FROM pg_attribute a, pg_type t lim
 SELECT span_type, span_operation, parameters, lvl from peek_ordered_spans;
   span_type   |                                     span_operation                                     | parameters | lvl 
 --------------+----------------------------------------------------------------------------------------+------------+-----
- Select query | SELECT information_schema._pg_truetypid(a, t) FROM pg_attribute a, pg_type t limit $1; | {1}        |   1
- Planner      | Planner                                                                                |            |   2
- ExecutorRun  | ExecutorRun                                                                            |            |   2
- Limit        | Limit                                                                                  |            |   3
- NestedLoop   | NestedLoop                                                                             |            |   4
- SeqScan      | SeqScan on pg_attribute a                                                              |            |   5
- Materialize  | Materialize                                                                            |            |   5
- SeqScan      | SeqScan on pg_type t                                                                   |            |   6
- Select query | Select query                                                                           |            |   3
- Planner      | Planner                                                                                |            |   4
- ExecutorRun  | ExecutorRun                                                                            |            |   4
- Result       | Result                                                                                 |            |   5
+ Select query | SELECT information_schema._pg_truetypid(a, t) FROM pg_attribute a, pg_type t limit $1; | {1}        |   0
+ Planner      | Planner                                                                                |            |   1
+ ExecutorRun  | ExecutorRun                                                                            |            |   1
+ Limit        | Limit                                                                                  |            |   2
+ NestedLoop   | NestedLoop                                                                             |            |   3
+ SeqScan      | SeqScan on pg_attribute a                                                              |            |   4
+ Materialize  | Materialize                                                                            |            |   4
+ SeqScan      | SeqScan on pg_type t                                                                   |            |   5
+ Select query | Select query                                                                           |            |   2
+ Planner      | Planner                                                                                |            |   3
+ ExecutorRun  | ExecutorRun                                                                            |            |   3
+ Result       | Result                                                                                 |            |   4
 (12 rows)
 
 -- Cleanup

--- a/expected/subxact.out
+++ b/expected/subxact.out
@@ -18,31 +18,31 @@ COMMIT;
 select span_operation, parameters, subxact_count, lvl FROM peek_ordered_spans WHERE span_operation NOT LIKE 'SAVEPOINT%';
                           span_operation                          | parameters  | subxact_count | lvl 
 ------------------------------------------------------------------+-------------+---------------+-----
- TransactionBlock                                                 |             |             0 |   1
- BEGIN;                                                           |             |             0 |   2
- ProcessUtility                                                   |             |             0 |   3
- ProcessUtility                                                   |             |             0 |   3
- INSERT INTO pg_tracing_test VALUES(generate_series($1, $2), $3); | {1,2,'aaa'} |             0 |   2
- Planner                                                          |             |             0 |   3
- ExecutorRun                                                      |             |             0 |   3
- Insert on pg_tracing_test                                        |             |             1 |   4
- ProjectSet                                                       |             |             1 |   5
- Result                                                           |             |             1 |   6
- ProcessUtility                                                   |             |             1 |   3
- INSERT INTO pg_tracing_test VALUES(generate_series($1, $2), $3); | {1,2,'aaa'} |             1 |   2
- Planner                                                          |             |             1 |   3
- ExecutorRun                                                      |             |             1 |   3
- Insert on pg_tracing_test                                        |             |             2 |   4
- ProjectSet                                                       |             |             2 |   5
- Result                                                           |             |             2 |   6
- ProcessUtility                                                   |             |             2 |   3
- SELECT $1;                                                       | {1}         |             2 |   2
- Planner                                                          |             |             2 |   3
- ExecutorRun                                                      |             |             2 |   3
- Result                                                           |             |             2 |   4
- COMMIT;                                                          |             |             2 |   2
- ProcessUtility                                                   |             |             2 |   3
- TransactionCommit                                                |             |             2 |   2
+ TransactionBlock                                                 |             |             0 |   0
+ BEGIN;                                                           |             |             0 |   1
+ ProcessUtility                                                   |             |             0 |   2
+ ProcessUtility                                                   |             |             0 |   2
+ INSERT INTO pg_tracing_test VALUES(generate_series($1, $2), $3); | {1,2,'aaa'} |             0 |   1
+ Planner                                                          |             |             0 |   2
+ ExecutorRun                                                      |             |             0 |   2
+ Insert on pg_tracing_test                                        |             |             1 |   3
+ ProjectSet                                                       |             |             1 |   4
+ Result                                                           |             |             1 |   5
+ ProcessUtility                                                   |             |             1 |   2
+ INSERT INTO pg_tracing_test VALUES(generate_series($1, $2), $3); | {1,2,'aaa'} |             1 |   1
+ Planner                                                          |             |             1 |   2
+ ExecutorRun                                                      |             |             1 |   2
+ Insert on pg_tracing_test                                        |             |             2 |   3
+ ProjectSet                                                       |             |             2 |   4
+ Result                                                           |             |             2 |   5
+ ProcessUtility                                                   |             |             2 |   2
+ SELECT $1;                                                       | {1}         |             2 |   1
+ Planner                                                          |             |             2 |   2
+ ExecutorRun                                                      |             |             2 |   2
+ Result                                                           |             |             2 |   3
+ COMMIT;                                                          |             |             2 |   1
+ ProcessUtility                                                   |             |             2 |   2
+ TransactionCommit                                                |             |             2 |   1
 (25 rows)
 
 -- Cleaning

--- a/expected/transaction.out
+++ b/expected/transaction.out
@@ -11,15 +11,15 @@ SET pg_tracing.caller_sample_rate = 1.0;
 SELECT span_type, span_operation, lvl FROM peek_ordered_spans where trace_id='00000000000000000000000000000001' AND span_type!='Commit';
     span_type     |  span_operation  | lvl 
 ------------------+------------------+-----
- TransactionBlock | TransactionBlock |   1
- Utility query    | BEGIN;           |   2
- ProcessUtility   | ProcessUtility   |   3
- Select query     | SELECT $1;       |   2
- Planner          | Planner          |   3
- ExecutorRun      | ExecutorRun      |   3
- Result           | Result           |   4
- Utility query    | COMMIT;          |   2
- ProcessUtility   | ProcessUtility   |   3
+ TransactionBlock | TransactionBlock |   0
+ Utility query    | BEGIN;           |   1
+ ProcessUtility   | ProcessUtility   |   2
+ Select query     | SELECT $1;       |   1
+ Planner          | Planner          |   2
+ ExecutorRun      | ExecutorRun      |   2
+ Result           | Result           |   3
+ Utility query    | COMMIT;          |   1
+ ProcessUtility   | ProcessUtility   |   2
 (9 rows)
 
 CALL clean_spans();
@@ -34,20 +34,20 @@ CALL clean_spans();
 SELECT span_type, span_operation, lvl FROM peek_ordered_spans where trace_id='00000000000000000000000000000002' AND span_type!='Commit';
     span_type     |  span_operation  | lvl 
 ------------------+------------------+-----
- TransactionBlock | TransactionBlock |   1
- Utility query    | BEGIN;           |   2
- ProcessUtility   | ProcessUtility   |   3
- Utility query    | COMMIT;          |   2
- ProcessUtility   | ProcessUtility   |   3
+ TransactionBlock | TransactionBlock |   0
+ Utility query    | BEGIN;           |   1
+ ProcessUtility   | ProcessUtility   |   2
+ Utility query    | COMMIT;          |   1
+ ProcessUtility   | ProcessUtility   |   2
 (5 rows)
 
 SELECT span_type, span_operation, lvl FROM peek_ordered_spans where trace_id='00000000000000000000000000000003';
   span_type   | span_operation | lvl 
 --------------+----------------+-----
- Select query | SELECT $1;     |   2
- Planner      | Planner        |   3
- ExecutorRun  | ExecutorRun    |   3
- Result       | Result         |   4
+ Select query | SELECT $1;     |   1
+ Planner      | Planner        |   2
+ ExecutorRun  | ExecutorRun    |   2
+ Result       | Result         |   3
 (4 rows)
 
 CALL clean_spans();
@@ -88,15 +88,15 @@ SELECT count(distinct(trace_id)) = 1 FROM pg_tracing_peek_spans;
 SELECT span_type, span_operation, lvl FROM peek_ordered_spans;
     span_type     |  span_operation  | lvl 
 ------------------+------------------+-----
- TransactionBlock | TransactionBlock |   1
- Select query     | SELECT $1;       |   2
- Planner          | Planner          |   3
- ExecutorRun      | ExecutorRun      |   3
- Result           | Result           |   4
- Select query     | SELECT $1;       |   2
- Planner          | Planner          |   3
- ExecutorRun      | ExecutorRun      |   3
- Result           | Result           |   4
+ TransactionBlock | TransactionBlock |   0
+ Select query     | SELECT $1;       |   1
+ Planner          | Planner          |   2
+ ExecutorRun      | ExecutorRun      |   2
+ Result           | Result           |   3
+ Select query     | SELECT $1;       |   1
+ Planner          | Planner          |   2
+ ExecutorRun      | ExecutorRun      |   2
+ Result           | Result           |   3
 (9 rows)
 
 CALL clean_spans();
@@ -137,15 +137,15 @@ SELECT count(distinct(trace_id)) = 1, count(distinct(parent_id)) = 1 FROM peek_o
 SELECT span_type, span_operation, lvl FROM peek_ordered_spans;
     span_type     |  span_operation  | lvl 
 ------------------+------------------+-----
- TransactionBlock | TransactionBlock |   1
- Select query     | SELECT $1;       |   2
- Planner          | Planner          |   3
- ExecutorRun      | ExecutorRun      |   3
- Result           | Result           |   4
- Select query     | SELECT $1;       |   2
- Planner          | Planner          |   3
- ExecutorRun      | ExecutorRun      |   3
- Result           | Result           |   4
+ TransactionBlock | TransactionBlock |   0
+ Select query     | SELECT $1;       |   1
+ Planner          | Planner          |   2
+ ExecutorRun      | ExecutorRun      |   2
+ Result           | Result           |   3
+ Select query     | SELECT $1;       |   1
+ Planner          | Planner          |   2
+ ExecutorRun      | ExecutorRun      |   2
+ Result           | Result           |   3
 (9 rows)
 
 CALL clean_spans();
@@ -156,17 +156,17 @@ END;
 SELECT span_type, span_operation, lvl FROM peek_ordered_spans;
      span_type     |                    span_operation                     | lvl 
 -------------------+-------------------------------------------------------+-----
- TransactionBlock  | TransactionBlock                                      |   1
- Utility query     | BEGIN;                                                |   2
- ProcessUtility    | ProcessUtility                                        |   3
- Insert query      | INSERT INTO test_modifications(a, b) VALUES ($1, $2); |   2
- Planner           | Planner                                               |   3
- ExecutorRun       | ExecutorRun                                           |   3
- Insert            | Insert on test_modifications                          |   4
- Result            | Result                                                |   5
- Utility query     | END;                                                  |   2
- ProcessUtility    | ProcessUtility                                        |   3
- TransactionCommit | TransactionCommit                                     |   2
+ TransactionBlock  | TransactionBlock                                      |   0
+ Utility query     | BEGIN;                                                |   1
+ ProcessUtility    | ProcessUtility                                        |   2
+ Insert query      | INSERT INTO test_modifications(a, b) VALUES ($1, $2); |   1
+ Planner           | Planner                                               |   2
+ ExecutorRun       | ExecutorRun                                           |   2
+ Insert            | Insert on test_modifications                          |   3
+ Result            | Result                                                |   4
+ Utility query     | END;                                                  |   1
+ ProcessUtility    | ProcessUtility                                        |   2
+ TransactionCommit | TransactionCommit                                     |   1
 (11 rows)
 
 SELECT span_id AS span_tx_block,
@@ -208,19 +208,19 @@ COMMIT;
 SELECT span_type, span_operation, lvl FROM peek_ordered_spans where trace_id='00000000000000000000000000000001';
     span_type     |  span_operation  | lvl 
 ------------------+------------------+-----
- TransactionBlock | TransactionBlock |   1
- Utility query    | BEGIN;           |   2
- ProcessUtility   | ProcessUtility   |   3
- Select query     | SELECT $1;       |   2
- Planner          | Planner          |   3
- ExecutorRun      | ExecutorRun      |   3
- Result           | Result           |   4
- Select query     | SELECT $1;       |   2
- Planner          | Planner          |   3
- ExecutorRun      | ExecutorRun      |   3
- Result           | Result           |   4
- Utility query    | COMMIT;          |   2
- ProcessUtility   | ProcessUtility   |   3
+ TransactionBlock | TransactionBlock |   0
+ Utility query    | BEGIN;           |   1
+ ProcessUtility   | ProcessUtility   |   2
+ Select query     | SELECT $1;       |   1
+ Planner          | Planner          |   2
+ ExecutorRun      | ExecutorRun      |   2
+ Result           | Result           |   3
+ Select query     | SELECT $1;       |   1
+ Planner          | Planner          |   2
+ ExecutorRun      | ExecutorRun      |   2
+ Result           | Result           |   3
+ Utility query    | COMMIT;          |   1
+ ProcessUtility   | ProcessUtility   |   2
 (13 rows)
 
 CALL reset_settings();

--- a/expected/trigger.out
+++ b/expected/trigger.out
@@ -134,23 +134,23 @@ SELECT :span_o_start >= :span_i_end  as second_trigger_starts_after_first,
 SELECT span_type, span_operation, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000001';
      span_type     |                                                   span_operation                                                    | lvl 
 -------------------+---------------------------------------------------------------------------------------------------------------------+-----
- Insert query      | INSERT INTO Employee VALUES($1,$2);                                                                                 |   1
- Planner           | Planner                                                                                                             |   2
- ExecutorRun       | ExecutorRun                                                                                                         |   2
- Insert            | Insert on employee                                                                                                  |   3
- Result            | Result                                                                                                              |   4
- ExecutorFinish    | ExecutorFinish                                                                                                      |   2
- Insert query      | INSERT INTO Employee_Audit (EmployeeId, LastName, EmpAdditionTime) VALUES(NEW.EmployeeId,NEW.LastName,current_date) |   3
- Planner           | Planner                                                                                                             |   4
- ExecutorRun       | ExecutorRun                                                                                                         |   4
- Insert            | Insert on employee_audit                                                                                            |   5
- Result            | Result                                                                                                              |   6
- Insert query      | INSERT INTO Employee_Audit (EmployeeId, LastName, EmpAdditionTime) VALUES(NEW.EmployeeId,NEW.LastName,current_date) |   3
- Planner           | Planner                                                                                                             |   4
- ExecutorRun       | ExecutorRun                                                                                                         |   4
- Insert            | Insert on employee_audit                                                                                            |   5
- Result            | Result                                                                                                              |   6
- TransactionCommit | TransactionCommit                                                                                                   |   1
+ Insert query      | INSERT INTO Employee VALUES($1,$2);                                                                                 |   0
+ Planner           | Planner                                                                                                             |   1
+ ExecutorRun       | ExecutorRun                                                                                                         |   1
+ Insert            | Insert on employee                                                                                                  |   2
+ Result            | Result                                                                                                              |   3
+ ExecutorFinish    | ExecutorFinish                                                                                                      |   1
+ Insert query      | INSERT INTO Employee_Audit (EmployeeId, LastName, EmpAdditionTime) VALUES(NEW.EmployeeId,NEW.LastName,current_date) |   2
+ Planner           | Planner                                                                                                             |   3
+ ExecutorRun       | ExecutorRun                                                                                                         |   3
+ Insert            | Insert on employee_audit                                                                                            |   4
+ Result            | Result                                                                                                              |   5
+ Insert query      | INSERT INTO Employee_Audit (EmployeeId, LastName, EmpAdditionTime) VALUES(NEW.EmployeeId,NEW.LastName,current_date) |   2
+ Planner           | Planner                                                                                                             |   3
+ ExecutorRun       | ExecutorRun                                                                                                         |   3
+ Insert            | Insert on employee_audit                                                                                            |   4
+ Result            | Result                                                                                                              |   5
+ TransactionCommit | TransactionCommit                                                                                                   |   0
 (17 rows)
 
 -- Check count of query_id
@@ -183,20 +183,20 @@ CREATE TRIGGER employee_delete_trigger
 SELECT trace_id, span_type, span_operation, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000001';
              trace_id             |     span_type     |                         span_operation                          | lvl 
 ----------------------------------+-------------------+-----------------------------------------------------------------+-----
- 00000000000000000000000000000001 | Insert query      | INSERT INTO before_trigger_table SELECT generate_series($1,$2); |   1
- 00000000000000000000000000000001 | Planner           | Planner                                                         |   2
- 00000000000000000000000000000001 | ExecutorRun       | ExecutorRun                                                     |   2
- 00000000000000000000000000000001 | Insert            | Insert on before_trigger_table                                  |   3
- 00000000000000000000000000000001 | ProjectSet        | ProjectSet                                                      |   4
- 00000000000000000000000000000001 | Result            | Result                                                          |   5
- 00000000000000000000000000000001 | Select query      | SELECT $1                                                       |   3
- 00000000000000000000000000000001 | Planner           | Planner                                                         |   4
- 00000000000000000000000000000001 | ExecutorRun       | ExecutorRun                                                     |   4
- 00000000000000000000000000000001 | Result            | Result                                                          |   5
- 00000000000000000000000000000001 | Select query      | SELECT $1                                                       |   3
- 00000000000000000000000000000001 | ExecutorRun       | ExecutorRun                                                     |   4
- 00000000000000000000000000000001 | Result            | Result                                                          |   5
- 00000000000000000000000000000001 | TransactionCommit | TransactionCommit                                               |   1
+ 00000000000000000000000000000001 | Insert query      | INSERT INTO before_trigger_table SELECT generate_series($1,$2); |   0
+ 00000000000000000000000000000001 | Planner           | Planner                                                         |   1
+ 00000000000000000000000000000001 | ExecutorRun       | ExecutorRun                                                     |   1
+ 00000000000000000000000000000001 | Insert            | Insert on before_trigger_table                                  |   2
+ 00000000000000000000000000000001 | ProjectSet        | ProjectSet                                                      |   3
+ 00000000000000000000000000000001 | Result            | Result                                                          |   4
+ 00000000000000000000000000000001 | Select query      | SELECT $1                                                       |   2
+ 00000000000000000000000000000001 | Planner           | Planner                                                         |   3
+ 00000000000000000000000000000001 | ExecutorRun       | ExecutorRun                                                     |   3
+ 00000000000000000000000000000001 | Result            | Result                                                          |   4
+ 00000000000000000000000000000001 | Select query      | SELECT $1                                                       |   2
+ 00000000000000000000000000000001 | ExecutorRun       | ExecutorRun                                                     |   3
+ 00000000000000000000000000000001 | Result            | Result                                                          |   4
+ 00000000000000000000000000000001 | TransactionCommit | TransactionCommit                                               |   0
 (14 rows)
 
 -- Call before trigger update
@@ -204,19 +204,19 @@ SELECT trace_id, span_type, span_operation, lvl from peek_ordered_spans where tr
 SELECT trace_id, span_type, span_operation, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000002';
              trace_id             |     span_type     |            span_operation             | lvl 
 ----------------------------------+-------------------+---------------------------------------+-----
- 00000000000000000000000000000002 | Update query      | UPDATE before_trigger_table set a=$1; |   1
- 00000000000000000000000000000002 | Planner           | Planner                               |   2
- 00000000000000000000000000000002 | ExecutorRun       | ExecutorRun                           |   2
- 00000000000000000000000000000002 | Update            | Update on before_trigger_table        |   3
- 00000000000000000000000000000002 | SeqScan           | SeqScan on before_trigger_table       |   4
- 00000000000000000000000000000002 | Select query      | SELECT $1                             |   3
- 00000000000000000000000000000002 | Planner           | Planner                               |   4
- 00000000000000000000000000000002 | ExecutorRun       | ExecutorRun                           |   4
- 00000000000000000000000000000002 | Result            | Result                                |   5
- 00000000000000000000000000000002 | Select query      | SELECT $1                             |   3
- 00000000000000000000000000000002 | ExecutorRun       | ExecutorRun                           |   4
- 00000000000000000000000000000002 | Result            | Result                                |   5
- 00000000000000000000000000000002 | TransactionCommit | TransactionCommit                     |   1
+ 00000000000000000000000000000002 | Update query      | UPDATE before_trigger_table set a=$1; |   0
+ 00000000000000000000000000000002 | Planner           | Planner                               |   1
+ 00000000000000000000000000000002 | ExecutorRun       | ExecutorRun                           |   1
+ 00000000000000000000000000000002 | Update            | Update on before_trigger_table        |   2
+ 00000000000000000000000000000002 | SeqScan           | SeqScan on before_trigger_table       |   3
+ 00000000000000000000000000000002 | Select query      | SELECT $1                             |   2
+ 00000000000000000000000000000002 | Planner           | Planner                               |   3
+ 00000000000000000000000000000002 | ExecutorRun       | ExecutorRun                           |   3
+ 00000000000000000000000000000002 | Result            | Result                                |   4
+ 00000000000000000000000000000002 | Select query      | SELECT $1                             |   2
+ 00000000000000000000000000000002 | ExecutorRun       | ExecutorRun                           |   3
+ 00000000000000000000000000000002 | Result            | Result                                |   4
+ 00000000000000000000000000000002 | TransactionCommit | TransactionCommit                     |   0
 (13 rows)
 
 -- Call before trigger delete
@@ -224,19 +224,19 @@ SELECT trace_id, span_type, span_operation, lvl from peek_ordered_spans where tr
 SELECT trace_id, span_type, span_operation, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000003';
              trace_id             |     span_type     |                span_operation                | lvl 
 ----------------------------------+-------------------+----------------------------------------------+-----
- 00000000000000000000000000000003 | Delete query      | DELETE FROM before_trigger_table where a=$1; |   1
- 00000000000000000000000000000003 | Planner           | Planner                                      |   2
- 00000000000000000000000000000003 | ExecutorRun       | ExecutorRun                                  |   2
- 00000000000000000000000000000003 | Delete            | Delete on before_trigger_table               |   3
- 00000000000000000000000000000003 | SeqScan           | SeqScan on before_trigger_table              |   4
- 00000000000000000000000000000003 | Select query      | SELECT $1                                    |   3
- 00000000000000000000000000000003 | Planner           | Planner                                      |   4
- 00000000000000000000000000000003 | ExecutorRun       | ExecutorRun                                  |   4
- 00000000000000000000000000000003 | Result            | Result                                       |   5
- 00000000000000000000000000000003 | Select query      | SELECT $1                                    |   3
- 00000000000000000000000000000003 | ExecutorRun       | ExecutorRun                                  |   4
- 00000000000000000000000000000003 | Result            | Result                                       |   5
- 00000000000000000000000000000003 | TransactionCommit | TransactionCommit                            |   1
+ 00000000000000000000000000000003 | Delete query      | DELETE FROM before_trigger_table where a=$1; |   0
+ 00000000000000000000000000000003 | Planner           | Planner                                      |   1
+ 00000000000000000000000000000003 | ExecutorRun       | ExecutorRun                                  |   1
+ 00000000000000000000000000000003 | Delete            | Delete on before_trigger_table               |   2
+ 00000000000000000000000000000003 | SeqScan           | SeqScan on before_trigger_table              |   3
+ 00000000000000000000000000000003 | Select query      | SELECT $1                                    |   2
+ 00000000000000000000000000000003 | Planner           | Planner                                      |   3
+ 00000000000000000000000000000003 | ExecutorRun       | ExecutorRun                                  |   3
+ 00000000000000000000000000000003 | Result            | Result                                       |   4
+ 00000000000000000000000000000003 | Select query      | SELECT $1                                    |   2
+ 00000000000000000000000000000003 | ExecutorRun       | ExecutorRun                                  |   3
+ 00000000000000000000000000000003 | Result            | Result                                       |   4
+ 00000000000000000000000000000003 | TransactionCommit | TransactionCommit                            |   0
 (13 rows)
 
 -- Check count of query_id
@@ -257,17 +257,17 @@ DETAIL:  Key (parent)=(blue) is not present in table "enumtest_parent".
 SELECT trace_id, span_type, span_operation, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000004';
              trace_id             |   span_type    |                                                                  span_operation                                                                  | lvl 
 ----------------------------------+----------------+--------------------------------------------------------------------------------------------------------------------------------------------------+-----
- 00000000000000000000000000000004 | Insert query   | INSERT INTO enumtest_child VALUES ($1);                                                                                                          |   1
- 00000000000000000000000000000004 | Planner        | Planner                                                                                                                                          |   2
- 00000000000000000000000000000004 | ExecutorRun    | ExecutorRun                                                                                                                                      |   2
- 00000000000000000000000000000004 | Insert         | Insert on enumtest_child                                                                                                                         |   3
- 00000000000000000000000000000004 | Result         | Result                                                                                                                                           |   4
- 00000000000000000000000000000004 | ExecutorFinish | ExecutorFinish                                                                                                                                   |   2
- 00000000000000000000000000000004 | Select query   | SELECT $2 FROM ONLY "public"."enumtest_parent" x WHERE "id"::pg_catalog.anyenum OPERATOR(pg_catalog.=) $1::pg_catalog.anyenum FOR KEY SHARE OF x |   3
- 00000000000000000000000000000004 | Planner        | Planner                                                                                                                                          |   4
- 00000000000000000000000000000004 | ExecutorRun    | ExecutorRun                                                                                                                                      |   4
- 00000000000000000000000000000004 | LockRows       | LockRows                                                                                                                                         |   5
- 00000000000000000000000000000004 | IndexScan      | IndexScan using enumtest_parent_pkey on enumtest_parent x                                                                                        |   6
+ 00000000000000000000000000000004 | Insert query   | INSERT INTO enumtest_child VALUES ($1);                                                                                                          |   0
+ 00000000000000000000000000000004 | Planner        | Planner                                                                                                                                          |   1
+ 00000000000000000000000000000004 | ExecutorRun    | ExecutorRun                                                                                                                                      |   1
+ 00000000000000000000000000000004 | Insert         | Insert on enumtest_child                                                                                                                         |   2
+ 00000000000000000000000000000004 | Result         | Result                                                                                                                                           |   3
+ 00000000000000000000000000000004 | ExecutorFinish | ExecutorFinish                                                                                                                                   |   1
+ 00000000000000000000000000000004 | Select query   | SELECT $2 FROM ONLY "public"."enumtest_parent" x WHERE "id"::pg_catalog.anyenum OPERATOR(pg_catalog.=) $1::pg_catalog.anyenum FOR KEY SHARE OF x |   2
+ 00000000000000000000000000000004 | Planner        | Planner                                                                                                                                          |   3
+ 00000000000000000000000000000004 | ExecutorRun    | ExecutorRun                                                                                                                                      |   3
+ 00000000000000000000000000000004 | LockRows       | LockRows                                                                                                                                         |   4
+ 00000000000000000000000000000004 | IndexScan      | IndexScan using enumtest_parent_pkey on enumtest_parent x                                                                                        |   5
 (11 rows)
 
 -- Test before trigger with copy dml
@@ -286,16 +286,16 @@ create trigger qqqbef before insert or update or delete on copydml_test
 SELECT trace_id, span_type, span_operation, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000005';
              trace_id             |     span_type     |                              span_operation                              | lvl 
 ----------------------------------+-------------------+--------------------------------------------------------------------------+-----
- 00000000000000000000000000000005 | Utility query     | copy (insert into copydml_test (t) values ('f') returning id) to stdout; |   1
- 00000000000000000000000000000005 | ProcessUtility    | ProcessUtility                                                           |   2
- 00000000000000000000000000000005 | Insert query      | copy (insert into copydml_test (t) values ($1) returning id) to stdout;  |   3
- 00000000000000000000000000000005 | Planner           | Planner                                                                  |   4
- 00000000000000000000000000000005 | ExecutorRun       | ExecutorRun                                                              |   4
- 00000000000000000000000000000005 | Insert            | Insert on copydml_test                                                   |   5
- 00000000000000000000000000000005 | Result            | Result                                                                   |   6
- 00000000000000000000000000000005 | Select query      | tg_op in ($7, $8)                                                        |   5
- 00000000000000000000000000000005 | Planner           | Planner                                                                  |   6
- 00000000000000000000000000000005 | TransactionCommit | TransactionCommit                                                        |   1
+ 00000000000000000000000000000005 | Utility query     | copy (insert into copydml_test (t) values ('f') returning id) to stdout; |   0
+ 00000000000000000000000000000005 | ProcessUtility    | ProcessUtility                                                           |   1
+ 00000000000000000000000000000005 | Insert query      | copy (insert into copydml_test (t) values ($1) returning id) to stdout;  |   2
+ 00000000000000000000000000000005 | Planner           | Planner                                                                  |   3
+ 00000000000000000000000000000005 | ExecutorRun       | ExecutorRun                                                              |   3
+ 00000000000000000000000000000005 | Insert            | Insert on copydml_test                                                   |   4
+ 00000000000000000000000000000005 | Result            | Result                                                                   |   5
+ 00000000000000000000000000000005 | Select query      | tg_op in ($7, $8)                                                        |   4
+ 00000000000000000000000000000005 | Planner           | Planner                                                                  |   5
+ 00000000000000000000000000000005 | TransactionCommit | TransactionCommit                                                        |   0
 (10 rows)
 
 -- Cleanup

--- a/expected/trigger_15.out
+++ b/expected/trigger_15.out
@@ -10,10 +10,10 @@
 SELECT trace_id, span_type, span_operation, lvl from peek_ordered_spans where trace_id='fed00000000000000000000000000001';
              trace_id             |   span_type    |                    span_operation                    | lvl 
 ----------------------------------+----------------+------------------------------------------------------+-----
- fed00000000000000000000000000001 | Utility query  | explain INSERT INTO before_trigger_table VALUES(10); |   1
- fed00000000000000000000000000001 | ProcessUtility | ProcessUtility                                       |   2
- fed00000000000000000000000000001 | Insert query   | explain INSERT INTO before_trigger_table VALUES($1); |   3
- fed00000000000000000000000000001 | Planner        | Planner                                              |   4
+ fed00000000000000000000000000001 | Utility query  | explain INSERT INTO before_trigger_table VALUES(10); |   0
+ fed00000000000000000000000000001 | ProcessUtility | ProcessUtility                                       |   1
+ fed00000000000000000000000000001 | Insert query   | explain INSERT INTO before_trigger_table VALUES($1); |   2
+ fed00000000000000000000000000001 | Planner        | Planner                                              |   3
 (4 rows)
 
 CALL clean_spans();

--- a/expected/trigger_16.out
+++ b/expected/trigger_16.out
@@ -10,10 +10,10 @@
 SELECT trace_id, span_type, span_operation, lvl from peek_ordered_spans where trace_id='fed00000000000000000000000000001';
              trace_id             |   span_type    |                    span_operation                    | lvl 
 ----------------------------------+----------------+------------------------------------------------------+-----
- fed00000000000000000000000000001 | Utility query  | explain INSERT INTO before_trigger_table VALUES($1); |   1
- fed00000000000000000000000000001 | ProcessUtility | ProcessUtility                                       |   2
- fed00000000000000000000000000001 | Insert query   | explain INSERT INTO before_trigger_table VALUES($1); |   3
- fed00000000000000000000000000001 | Planner        | Planner                                              |   4
+ fed00000000000000000000000000001 | Utility query  | explain INSERT INTO before_trigger_table VALUES($1); |   0
+ fed00000000000000000000000000001 | ProcessUtility | ProcessUtility                                       |   1
+ fed00000000000000000000000000001 | Insert query   | explain INSERT INTO before_trigger_table VALUES($1); |   2
+ fed00000000000000000000000000001 | Planner        | Planner                                              |   3
 (4 rows)
 
 CALL clean_spans();

--- a/expected/utility.out
+++ b/expected/utility.out
@@ -262,23 +262,23 @@ select count(distinct(trace_id)) from pg_tracing_peek_spans;
 select span_operation, parameters, lvl from peek_ordered_spans;
                       span_operation                       | parameters | lvl 
 -----------------------------------------------------------+------------+-----
- PREPARE test_prepared_one_param_2 (integer) AS SELECT $1; |            |   1
- ProcessUtility                                            |            |   2
- PREPARE test_prepared_one_param_2 (integer) AS SELECT $1; |            |   3
- EXECUTE test_prepared_one_param_2(100);                   |            |   1
- ProcessUtility                                            |            |   2
- PREPARE test_prepared_one_param_2 (integer) AS SELECT $1; | {100}      |   3
- Planner                                                   |            |   4
- ExecutorRun                                               |            |   4
- Result                                                    |            |   5
+ PREPARE test_prepared_one_param_2 (integer) AS SELECT $1; |            |   0
+ ProcessUtility                                            |            |   1
+ PREPARE test_prepared_one_param_2 (integer) AS SELECT $1; |            |   2
+ EXECUTE test_prepared_one_param_2(100);                   |            |   0
+ ProcessUtility                                            |            |   1
+ PREPARE test_prepared_one_param_2 (integer) AS SELECT $1; | {100}      |   2
+ Planner                                                   |            |   3
+ ExecutorRun                                               |            |   3
+ Result                                                    |            |   4
 (9 rows)
 
 -- Check the top span (standalone top span has trace_id=parent_id)
 select span_operation, parameters, lvl from peek_ordered_spans where right(trace_id, 16) = parent_id;
                       span_operation                       | parameters | lvl 
 -----------------------------------------------------------+------------+-----
- PREPARE test_prepared_one_param_2 (integer) AS SELECT $1; |            |   1
- EXECUTE test_prepared_one_param_2(100);                   |            |   1
+ PREPARE test_prepared_one_param_2 (integer) AS SELECT $1; |            |   0
+ EXECUTE test_prepared_one_param_2(100);                   |            |   0
 (2 rows)
 
 CALL clean_spans();
@@ -289,14 +289,14 @@ PREPARE test_insert (integer, text) AS INSERT INTO pg_tracing_test(a, b) VALUES 
 select trace_id, span_operation, parameters, lvl from peek_ordered_spans WHERE trace_id='00000000000000000000000000000001';
              trace_id             |                                      span_operation                                       | parameters | lvl 
 ----------------------------------+-------------------------------------------------------------------------------------------+------------+-----
- 00000000000000000000000000000001 | EXECUTE test_insert(100, '2');                                                            |            |   1
- 00000000000000000000000000000001 | ProcessUtility                                                                            |            |   2
- 00000000000000000000000000000001 | PREPARE test_insert (integer, text) AS INSERT INTO pg_tracing_test(a, b) VALUES ($1, $2); | {100,2}    |   3
- 00000000000000000000000000000001 | Planner                                                                                   |            |   4
- 00000000000000000000000000000001 | ExecutorRun                                                                               |            |   4
- 00000000000000000000000000000001 | Insert on pg_tracing_test                                                                 |            |   5
- 00000000000000000000000000000001 | Result                                                                                    |            |   6
- 00000000000000000000000000000001 | TransactionCommit                                                                         |            |   1
+ 00000000000000000000000000000001 | EXECUTE test_insert(100, '2');                                                            |            |   0
+ 00000000000000000000000000000001 | ProcessUtility                                                                            |            |   1
+ 00000000000000000000000000000001 | PREPARE test_insert (integer, text) AS INSERT INTO pg_tracing_test(a, b) VALUES ($1, $2); | {100,2}    |   2
+ 00000000000000000000000000000001 | Planner                                                                                   |            |   3
+ 00000000000000000000000000000001 | ExecutorRun                                                                               |            |   3
+ 00000000000000000000000000000001 | Insert on pg_tracing_test                                                                 |            |   4
+ 00000000000000000000000000000001 | Result                                                                                    |            |   5
+ 00000000000000000000000000000001 | TransactionCommit                                                                         |            |   0
 (8 rows)
 
 -- We should have only two query_ids
@@ -334,21 +334,21 @@ select count(distinct(trace_id)) from pg_tracing_peek_spans;
 select span_operation, parameters, lvl from peek_ordered_spans;
                      span_operation                      | parameters | lvl 
 ---------------------------------------------------------+------------+-----
- EXECUTE test_prepared_one_param(200);                   |            |   1
- ProcessUtility                                          |            |   2
- PREPARE test_prepared_one_param (integer) AS SELECT $1; |            |   3
- ExecutorRun                                             |            |   4
- Result                                                  |            |   5
- SET plan_cache_mode TO DEFAULT;                         |            |   1
- ProcessUtility                                          |            |   2
+ EXECUTE test_prepared_one_param(200);                   |            |   0
+ ProcessUtility                                          |            |   1
+ PREPARE test_prepared_one_param (integer) AS SELECT $1; |            |   2
+ ExecutorRun                                             |            |   3
+ Result                                                  |            |   4
+ SET plan_cache_mode TO DEFAULT;                         |            |   0
+ ProcessUtility                                          |            |   1
 (7 rows)
 
 -- Check the top span (standalone top span has trace_id=parent_id)
 select span_operation, parameters, lvl from peek_ordered_spans where right(trace_id, 16) = parent_id;
             span_operation             | parameters | lvl 
 ---------------------------------------+------------+-----
- EXECUTE test_prepared_one_param(200); |            |   1
- SET plan_cache_mode TO DEFAULT;       |            |   1
+ EXECUTE test_prepared_one_param(200); |            |   0
+ SET plan_cache_mode TO DEFAULT;       |            |   0
 (2 rows)
 
 CALL clean_spans();
@@ -358,8 +358,8 @@ ERROR:  extension "pg_tracing" already exists
 select span_operation, parameters, sql_error_code, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000001';
         span_operation        | parameters | sql_error_code | lvl 
 ------------------------------+------------+----------------+-----
- CREATE EXTENSION pg_tracing; |            | 42710          |   1
- ProcessUtility               |            | 42710          |   2
+ CREATE EXTENSION pg_tracing; |            | 42710          |   0
+ ProcessUtility               |            | 42710          |   1
 (2 rows)
 
 -- Create test table
@@ -368,9 +368,9 @@ select span_operation, parameters, sql_error_code, lvl from peek_ordered_spans w
 select trace_id, span_type, span_operation, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000002';
              trace_id             |     span_type     |                   span_operation                    | lvl 
 ----------------------------------+-------------------+-----------------------------------------------------+-----
- 00000000000000000000000000000002 | Utility query     | CREATE TABLE test_create_table (a int, b char(20)); |   1
- 00000000000000000000000000000002 | ProcessUtility    | ProcessUtility                                      |   2
- 00000000000000000000000000000002 | TransactionCommit | TransactionCommit                                   |   1
+ 00000000000000000000000000000002 | Utility query     | CREATE TABLE test_create_table (a int, b char(20)); |   0
+ 00000000000000000000000000000002 | ProcessUtility    | ProcessUtility                                      |   1
+ 00000000000000000000000000000002 | TransactionCommit | TransactionCommit                                   |   0
 (3 rows)
 
 /*dddbs='postgres.db',traceparent='00-00000000000000000000000000000003-0000000000000003-01'*/ CREATE INDEX test_create_table_index ON test_create_table (a);
@@ -378,9 +378,9 @@ select trace_id, span_type, span_operation, lvl from peek_ordered_spans where tr
 select trace_id, span_type, span_operation, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000003';
              trace_id             |     span_type     |                         span_operation                         | lvl 
 ----------------------------------+-------------------+----------------------------------------------------------------+-----
- 00000000000000000000000000000003 | Utility query     | CREATE INDEX test_create_table_index ON test_create_table (a); |   1
- 00000000000000000000000000000003 | ProcessUtility    | ProcessUtility                                                 |   2
- 00000000000000000000000000000003 | TransactionCommit | TransactionCommit                                              |   1
+ 00000000000000000000000000000003 | Utility query     | CREATE INDEX test_create_table_index ON test_create_table (a); |   0
+ 00000000000000000000000000000003 | ProcessUtility    | ProcessUtility                                                 |   1
+ 00000000000000000000000000000003 | TransactionCommit | TransactionCommit                                              |   0
 (3 rows)
 
 CREATE OR REPLACE FUNCTION function_with_error(IN anyarray, OUT x anyelement, OUT n int)
@@ -409,29 +409,29 @@ CONTEXT:  SQL function "function_with_error" during startup
 select trace_id, span_type, span_operation, sql_error_code, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000004';
              trace_id             |  span_type   |                        span_operation                        | sql_error_code | lvl 
 ----------------------------------+--------------+--------------------------------------------------------------+----------------+-----
- 00000000000000000000000000000004 | Select query | select function_with_error($1::int[]);                       | 42P13          |   1
- 00000000000000000000000000000004 | Planner      | Planner                                                      | 00000          |   2
- 00000000000000000000000000000004 | ExecutorRun  | ExecutorRun                                                  | 42P13          |   2
- 00000000000000000000000000000004 | ProjectSet   | ProjectSet                                                   | 42P13          |   3
- 00000000000000000000000000000004 | Result       | Result                                                       | 42P13          |   4
- 00000000000000000000000000000004 | Select query | select s from pg_catalog.generate_series($1, $2, $3) as g(s) | 00000          |   4
+ 00000000000000000000000000000004 | Select query | select function_with_error($1::int[]);                       | 42P13          |   0
+ 00000000000000000000000000000004 | Planner      | Planner                                                      | 00000          |   1
+ 00000000000000000000000000000004 | ExecutorRun  | ExecutorRun                                                  | 42P13          |   1
+ 00000000000000000000000000000004 | ProjectSet   | ProjectSet                                                   | 42P13          |   2
+ 00000000000000000000000000000004 | Result       | Result                                                       | 42P13          |   3
+ 00000000000000000000000000000004 | Select query | select s from pg_catalog.generate_series($1, $2, $3) as g(s) | 00000          |   3
 (6 rows)
 
 /*dddbs='postgres.db',traceparent='00-00000000000000000000000000000005-0000000000000005-01'*/ ANALYZE test_create_table;
 select trace_id, span_type, span_operation, sql_error_code, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000005';
              trace_id             |   span_type    |       span_operation       | sql_error_code | lvl 
 ----------------------------------+----------------+----------------------------+----------------+-----
- 00000000000000000000000000000005 | Utility query  | ANALYZE test_create_table; | 00000          |   1
- 00000000000000000000000000000005 | ProcessUtility | ProcessUtility             | 00000          |   2
+ 00000000000000000000000000000005 | Utility query  | ANALYZE test_create_table; | 00000          |   0
+ 00000000000000000000000000000005 | ProcessUtility | ProcessUtility             | 00000          |   1
 (2 rows)
 
 /*dddbs='postgres.db',traceparent='00-00000000000000000000000000000006-0000000000000006-01'*/ DROP TABLE test_create_table;
 select trace_id, span_type, span_operation, sql_error_code, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000006';
              trace_id             |     span_type     |        span_operation         | sql_error_code | lvl 
 ----------------------------------+-------------------+-------------------------------+----------------+-----
- 00000000000000000000000000000006 | Utility query     | DROP TABLE test_create_table; | 00000          |   1
- 00000000000000000000000000000006 | ProcessUtility    | ProcessUtility                | 00000          |   2
- 00000000000000000000000000000006 | TransactionCommit | TransactionCommit             | 00000          |   1
+ 00000000000000000000000000000006 | Utility query     | DROP TABLE test_create_table; | 00000          |   0
+ 00000000000000000000000000000006 | ProcessUtility    | ProcessUtility                | 00000          |   1
+ 00000000000000000000000000000006 | TransactionCommit | TransactionCommit             | 00000          |   0
 (3 rows)
 
 -- Check VACUUM ANALYZE call
@@ -439,9 +439,9 @@ select trace_id, span_type, span_operation, sql_error_code, lvl from peek_ordere
 select trace_id, span_type, span_operation, sql_error_code, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000007';
              trace_id             |     span_type     |         span_operation          | sql_error_code | lvl 
 ----------------------------------+-------------------+---------------------------------+----------------+-----
- 00000000000000000000000000000007 | Utility query     | VACUUM ANALYZE pg_tracing_test; | 00000          |   1
- 00000000000000000000000000000007 | ProcessUtility    | ProcessUtility                  | 00000          |   2
- 00000000000000000000000000000007 | TransactionCommit | TransactionCommit               | 00000          |   1
+ 00000000000000000000000000000007 | Utility query     | VACUUM ANALYZE pg_tracing_test; | 00000          |   0
+ 00000000000000000000000000000007 | ProcessUtility    | ProcessUtility                  | 00000          |   1
+ 00000000000000000000000000000007 | TransactionCommit | TransactionCommit               | 00000          |   0
 (3 rows)
 
 -- Cleanup

--- a/expected/utility.out
+++ b/expected/utility.out
@@ -57,16 +57,6 @@ SET pg_tracing.sample_rate = 1.0;
 DROP EXTENSION pg_tracing;
 CREATE EXTENSION pg_tracing;
 SET pg_tracing.sample_rate = 0.0;
--- View displaying spans with their nested level
-CREATE VIEW peek_spans_with_level AS
-    WITH RECURSIVE list_trace_spans AS (
-        SELECT p.*, 1 as lvl
-        FROM pg_tracing_peek_spans p where not parent_id=ANY(SELECT span_id from pg_tracing_peek_spans)
-      UNION ALL
-        SELECT s.*, lvl + 1
-        FROM pg_tracing_peek_spans s, list_trace_spans st
-        WHERE s.parent_id = st.span_id
-    ) SELECT * FROM list_trace_spans;
 -- Create utility view to keep order stable
 CREATE VIEW peek_ordered_spans AS
     WITH oldest_start AS (
@@ -75,7 +65,7 @@ CREATE VIEW peek_ordered_spans AS
     ) select *,
         extract(MICROSECONDS FROM age(span_start, oldest_start.min_start)) as us_start,
         extract(MICROSECONDS FROM age(span_end, oldest_start.min_start)) as us_end
-        FROM peek_spans_with_level, oldest_start order by span_start, lvl, span_end, deparse_info;
+        FROM pg_tracing_peek_spans_with_level, oldest_start order by span_start, lvl, span_end, deparse_info;
 -- Column type to convert json to record
 create type span_json as ("traceId" text, "parentSpanId" text, "spanId" text, name text, "startTimeUnixNano" text, "endTimeUnixNano" text, attributes jsonb, kind int, status jsonb);
 CREATE VIEW peek_json_spans AS

--- a/pg_tracing--0.1.0.sql
+++ b/pg_tracing--0.1.0.sql
@@ -97,6 +97,17 @@ CREATE VIEW pg_tracing_info AS
 CREATE VIEW pg_tracing_peek_spans AS
   SELECT * FROM pg_tracing_spans(false);
 
+-- Spans with their level
+CREATE VIEW pg_tracing_peek_spans_with_level AS
+    WITH RECURSIVE list_trace_spans AS (
+        SELECT p.*, 1 as lvl
+        FROM pg_tracing_peek_spans p where not parent_id=ANY(SELECT span_id from pg_tracing_peek_spans)
+      UNION ALL
+        SELECT s.*, lvl + 1
+        FROM pg_tracing_peek_spans s, list_trace_spans st
+        WHERE s.parent_id = st.span_id
+    ) SELECT * FROM list_trace_spans;
+
 CREATE VIEW pg_tracing_consume_spans AS
   SELECT * FROM pg_tracing_spans(true);
 

--- a/pg_tracing--0.1.0.sql
+++ b/pg_tracing--0.1.0.sql
@@ -100,7 +100,7 @@ CREATE VIEW pg_tracing_peek_spans AS
 -- Spans with their level
 CREATE VIEW pg_tracing_peek_spans_with_level AS
     WITH RECURSIVE list_trace_spans AS (
-        SELECT p.*, 1 as lvl
+        SELECT p.*, 0 as lvl
         FROM pg_tracing_peek_spans p where not parent_id=ANY(SELECT span_id from pg_tracing_peek_spans)
       UNION ALL
         SELECT s.*, lvl + 1

--- a/pg_tracing--0.1.0.sql
+++ b/pg_tracing--0.1.0.sql
@@ -108,6 +108,11 @@ CREATE VIEW pg_tracing_peek_spans_with_level AS
         WHERE s.parent_id = st.span_id
     ) SELECT * FROM list_trace_spans;
 
+CREATE VIEW pg_tracing_peek_spans_tree AS
+  SELECT trace_id, lpad(span_operation, length(span_operation) + lvl * 2, '_'), span_id, parent_id, span_start, span_end, lvl
+  FROM pg_tracing_peek_spans_with_level s
+  ORDER BY trace_id, span_start;
+
 CREATE VIEW pg_tracing_consume_spans AS
   SELECT * FROM pg_tracing_spans(true);
 

--- a/sql/cleanup.sql
+++ b/sql/cleanup.sql
@@ -3,7 +3,6 @@ DROP TABLE pg_tracing_test;
 DROP function test_function_project_set;
 DROP function test_function_result;
 DROP VIEW peek_ordered_spans;
-DROP VIEW peek_spans_with_level;
 DROP VIEW peek_ordered_json_spans;
 DROP VIEW peek_json_spans_with_level;
 DROP VIEW peek_json_spans;

--- a/sql/planstate_subplans.sql
+++ b/sql/planstate_subplans.sql
@@ -5,7 +5,7 @@ WHEN MATCHED THEN UPDATE SET v = (SELECT b || ' merge update' FROM cte_init WHER
 WHEN NOT MATCHED THEN INSERT VALUES(o.k, o.v);
 
 -- Check generated spans for init plan
-SELECT span_operation, deparse_info, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000001' AND lvl < 4;
+SELECT span_operation, deparse_info, parameters, lvl from peek_ordered_spans where trace_id='00000000000000000000000000000001' AND lvl < 3;
 
 -- +----------------------------------------------------------+
 -- | A: Merge on m                                            |

--- a/sql/psql_extended_tx.sql
+++ b/sql/psql_extended_tx.sql
@@ -1,0 +1,99 @@
+-- Only trace individual statements using unnamed prepared statement
+BEGIN;
+/*traceparent='00-00000000000000000000000000000002-0000000000000001-01'*/ select $1 \parse ''
+\bind_named '' 1 \g
+/*traceparent='00-00000000000000000000000000000003-0000000000000001-01'*/ select $1, $2 \parse ''
+\bind_named '' 1 2 \g
+/*traceparent='00-00000000000000000000000000000004-0000000000000001-01'*/ select $1, $2, $3 \parse ''
+\bind_named '' 1 2 3 \g
+COMMIT;
+SELECT trace_id, span_type, span_operation, parameters, lvl FROM peek_ordered_spans;
+CALL clean_spans();
+
+-- Mix begin in simple protocol with extended protocol usage
+/*traceparent='00-00000000000000000000000000000005-0000000000000001-01'*/ BEGIN;
+select $1 \parse ''
+\bind_named '' 1 \g
+select $1, $2 \parse ''
+\bind_named '' 1 2 \g
+select $1, $2, $3 \parse ''
+\bind_named '' 1 2 3 \g
+COMMIT;
+SELECT trace_id, span_type, span_operation, parameters, lvl FROM peek_ordered_spans;
+CALL clean_spans();
+
+-- Test using extended protocol for utility statement
+/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000006-0000000000000001-01'*/ BEGIN \parse begin_stmt
+\bind_named begin_stmt \g
+SELECT 1 \parse stmt_mix_1
+\bind_named stmt_mix_1 \g
+SELECT 1, 2 \parse stmt_mix_2
+\bind_named stmt_mix_2 \g
+COMMIT \parse commit_stmt
+\bind_named commit_stmt \g
+
+SELECT span_type, span_operation, parameters, lvl FROM peek_ordered_spans
+    where trace_id='00000000000000000000000000000006' AND lvl <= 2;
+SELECT get_epoch(span_end) as span_select_1_end
+	from pg_tracing_peek_spans where span_operation='SELECT $1' and trace_id='00000000000000000000000000000006' \gset
+SELECT get_epoch(span_start) as span_select_2_start,
+       get_epoch(span_end) as span_select_2_end
+	from pg_tracing_peek_spans where span_operation='SELECT $1, $2' and trace_id='00000000000000000000000000000006' \gset
+SELECT get_epoch(span_start) as span_commit_start
+	from pg_tracing_peek_spans where span_operation='COMMIT' and trace_id='00000000000000000000000000000006' \gset
+SELECT :span_select_1_end <= :span_select_2_start,
+    :span_select_2_end <= :span_commit_start;
+CALL clean_spans();
+
+-- Test with extended protocol while reusing prepared stmts
+/*dddbs='postgres.db',traceparent='00-00000000000000000000000000000001-0000000000000001-01'*/ BEGIN;
+\bind_named stmt_mix_1 \g
+\bind_named stmt_mix_2 \g
+SELECT 1, 2, 3 \parse stmt_mix_3
+\bind_named stmt_mix_3 \g
+\bind_named commit_stmt \g
+
+SELECT span_type, span_operation, parameters, lvl FROM peek_ordered_spans;
+SELECT get_epoch(span_end) as span_select_1_end
+	from pg_tracing_peek_spans where span_operation='SELECT 1' and trace_id='00000000000000000000000000000001' \gset
+SELECT get_epoch(span_start) as span_select_2_start,
+       get_epoch(span_end) as span_select_2_end
+	from pg_tracing_peek_spans where span_operation='SELECT 1, 2' and trace_id='00000000000000000000000000000001' \gset
+SELECT get_epoch(span_start) as span_select_3_start,
+       get_epoch(span_end) as span_select_3_end
+	from pg_tracing_peek_spans where span_operation='SELECT $1, $2, $3' and trace_id='00000000000000000000000000000001' \gset
+SELECT get_epoch(span_start) as span_commit_start
+	from pg_tracing_peek_spans where span_operation='COMMIT' and trace_id='00000000000000000000000000000001' \gset
+SELECT :span_select_1_end <= :span_select_2_start,
+    :span_select_2_end <= :span_select_3_start,
+    :span_select_3_end <= :span_commit_start;
+DEALLOCATE ALL;
+CALL clean_spans();
+
+-- Test extended protocol while tracing everything
+SET pg_tracing.sample_rate = 1.0;
+BEGIN \parse begin_stmt
+\bind_named begin_stmt \g
+SELECT 1 \parse stmt_mix_1
+\bind_named stmt_mix_1 \g
+SELECT 1, 2 \parse stmt_mix_2
+\bind_named stmt_mix_2 \g
+COMMIT \parse commit_stmt
+\bind_named commit_stmt \g
+
+SELECT span_type, span_operation, parameters, lvl FROM peek_ordered_spans
+    WHERE lvl <= 2;
+SELECT get_epoch(span_end) as span_select_1_end
+	from pg_tracing_peek_spans where span_operation='SELECT $1' \gset
+SELECT get_epoch(span_start) as span_select_2_start,
+       get_epoch(span_end) as span_select_2_end
+	from pg_tracing_peek_spans where span_operation='SELECT $1, $2' \gset
+SELECT get_epoch(span_start) as span_commit_start
+	from pg_tracing_peek_spans where span_operation='COMMIT' \gset
+SELECT :span_select_1_end <= :span_select_2_start,
+    :span_select_2_end <= :span_commit_start;
+CALL clean_spans();
+
+-- Cleanup
+CALL reset_settings();
+CALL clean_spans();


### PR DESCRIPTION
- Add peek span view with level to the extension script. lvl now starts at 0
- Create a pg_tracing_peek_spans_tree view to visualise spans as a tree hierarchy 